### PR TITLE
REPv1 -> REP, add REPv2

### DIFF
--- a/uniswap-default.tokenlist.json
+++ b/uniswap-default.tokenlist.json
@@ -687,12 +687,20 @@
       "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1C5db575E2Ff833E46a2E9864C22F4B22E0B37C2/logo.png"
     },
     {
-      "name": "Augur v1 Reputation",
+      "name": "Reputation Augur v1",
       "address": "0x1985365e9f78359a9B6AD760e32412f4a445E862",
       "symbol": "REP",
       "decimals": 18,
       "chainId": 1,
       "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1985365e9f78359a9B6AD760e32412f4a445E862/logo.png"
+    },
+    {
+      "name": "Reputation Augur v2",
+      "address": "0x221657776846890989a759BA2973e427DfF5C9bB",
+      "symbol": "REPv2",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x221657776846890989a759BA2973e427DfF5C9bB/logo.png"
     },
     {
       "name": "Darwinia Network Native Token",

--- a/uniswap-default.tokenlist.json
+++ b/uniswap-default.tokenlist.json
@@ -689,7 +689,7 @@
     {
       "name": "Augur v1 Reputation",
       "address": "0x1985365e9f78359a9B6AD760e32412f4a445E862",
-      "symbol": "REPv1",
+      "symbol": "REP",
       "decimals": 18,
       "chainId": 1,
       "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1985365e9f78359a9B6AD760e32412f4a445E862/logo.png"


### PR DESCRIPTION
Referencing issue here: https://github.com/Uniswap/uniswap-interface/pull/945#issuecomment-664406587

REP was going to originally be renamed to REPv1, however that decision was reverted.

Sources: 

https://twitter.com/AugurProject/status/1281707502233501698

https://github.com/AugurProject/V2Migration/blob/master/V2Deployment.md#REP-Naming-Convention