### PR TITLE
Add ZAP TOKEN to the token list and resolves Uniswap/default-token-list#127 

### DIFF
--- a/uniswap-default.tokenlist.json
+++ b/uniswap-default.tokenlist.json
@@ -1053,6 +1053,14 @@
       "decimals": 18,
       "chainId": 3,
       "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xaD6D458402F60fD3Bd25163575031ACDce07538D/logo.png"
+    },
+    {
+      "name": "ZAP TOKEN",
+      "address": "0x6781a0f84c7e9e846dcb84a9a5bd49333067b104",
+      "symbol": "ZAP",
+      "decimals": 18,
+      "chainId": 1,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6781a0F84c7E9e846DCb84A9a5bd49333067b104/logo.png"
     }
   ]
 }


### PR DESCRIPTION
Updated uniswap-default.tokenlist.json to resolve issue #127 and add ZAP TOKEN to the token list.
