### PR TITLE
Update ANT

### DIFF
--- a/src/tokens/mainnet.json
+++ b/src/tokens/mainnet.json
@@ -48,9 +48,9 @@
     "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xcD62b1C403fa761BAadFC74C525ce2B51780b184/logo.png"
   },
   {
-    "name": "Aragon Network Token",
+    "name": "Aragon Network Token v1",
     "address": "0x960b236A07cf122663c4303350609A66A7B288C0",
-    "symbol": "ANT",
+    "symbol": "ANT (old)",
     "decimals": 18,
     "chainId": 1,
     "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x960b236A07cf122663c4303350609A66A7B288C0/logo.png"

--- a/src/tokens/mainnet.json
+++ b/src/tokens/mainnet.json
@@ -48,6 +48,14 @@
     "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xcD62b1C403fa761BAadFC74C525ce2B51780b184/logo.png"
   },
   {
+    "name": "Aragon Network Token v2",
+    "address": "0xa117000000f279D81A1D3cc75430fAA017FA5A2e",
+    "symbol": "ANT",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xa117000000f279D81A1D3cc75430fAA017FA5A2e/logo.png"
+  },
+  {
     "name": "Aragon Network Token v1",
     "address": "0x960b236A07cf122663c4303350609A66A7B288C0",
     "symbol": "ANT (old)",


### PR DESCRIPTION
Adds ANTv2 ([`0xa117000000f279D81A1D3cc75430fAA017FA5A2e`](https://etherscan.io/address/0xa117000000f279d81a1d3cc75430faa017fa5a2e#code)).

- [Announcement](https://aragon.org/blog/antv2)
- [Repo](https://github.com/aragon/aragon-network-token)

-----

If it's possible to keep the old token in the list for a while, as it's still a fully-functional and transferable token, this is how we'd prefer to display it. However, if we can only keep one (especially as we think ANTv1 liquidity will be quite low soon), we'd prefer to only keep the new token.

The logo at `https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xa117000000f279D81A1D3cc75430fAA017FA5A2e/logo.png` will be available once the related PR is merged at `trustwallet/assets`.