### PR TITLE
Add CORE token to the default list

### DIFF
--- a/src/tokens/mainnet.json
+++ b/src/tokens/mainnet.json
@@ -998,5 +998,13 @@
     "decimals": 18,
     "chainId": 1,
     "logoURI": "ipfs://QmXttGpZrECX5qCyXbBQiqgQNytVGeZW5Anewvh2jc4psg"
+  },
+  {
+    "name": "cVault.finance",
+    "address": "0x62359Ed7505Efc61FF1D56fEF82158CcaffA23D7",
+    "symbol": "CORE",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x62359Ed7505Efc61FF1D56fEF82158CcaffA23D7/logo.png"
   }
 ]


### PR DESCRIPTION
Please add CORE to the Uniswap default list, i keep getting reports of people having troubles finding it.
This would close #583

@NoahZinsmeister Please review if everything is correct and all requirements are met