### PR TITLE
Add ALBT - AllianceBlock Token

### DIFF
--- a/src/tokens/mainnet.json
+++ b/src/tokens/mainnet.json
@@ -1,4 +1,12 @@
 [
+    {
+    "name": "AllianceBlock Token",
+    "address": "0x00a8b738E453fFd858a7edf03bcCfe20412f0Eb0",
+    "symbol": "ALBT",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x00a8b738E453fFd858a7edf03bcCfe20412f0Eb0/logo.png"
+  },
   {
     "name": "Wrapped Ether",
     "address": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",


### PR DESCRIPTION
[x] I understand that token listing is not required to use the Uniswap Interface with a token.
[x] I understand that filing an issue or adding liquidity does not guarantee addition to the Uniswap default token list.
[x] I will not ping the Discord about this listing request.
Please provide the following information for your token.

Token Address: 0x00a8b738E453fFd858a7edf03bcCfe20412f0Eb0
Token Name (from contract): AllianceBlock Token
Token Decimals (from contract): 18
Token Symbol (from contract): ALBT
Uniswap V2 Pair Address of Token: 0xe5c5227d8105d8d5f26ff3634eb52e2d7cc15b50

Link to the official homepage of token: https://www.allianceblock.io/
Link to CoinMarketCap or CoinGecko page of token: https://www.coingecko.com/en/coins/allianceblock

This would close #585 