### PR TITLE
GLM (Golem Network Token) added

### DIFF
--- a/src/tokens/mainnet.json
+++ b/src/tokens/mainnet.json
@@ -999,4 +999,13 @@
     "chainId": 1,
     "logoURI": "ipfs://QmXttGpZrECX5qCyXbBQiqgQNytVGeZW5Anewvh2jc4psg"
   }
+  ,
+  {
+    "name": "Golem",
+    "address": "0x7DD9c5Cba05E151C895FDe1CF355C9A1D5DA6429",
+    "symbol": "GLM",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://user-images.githubusercontent.com/35585644/99983868-b5a44a80-2dac-11eb-8749-edc382437b56.png"
+  }
 ]


### PR DESCRIPTION
PR to add GLM (the migrated ERC20 of GNT) to default-token-list #616 

Please provide the following information for your token.

Token Address: 0x7DD9c5Cba05E151C895FDe1CF355C9A1D5DA6429
Token Name (from contract): Golem Network Token
Token Decimals (from contract): 18
Token Symbol (from contract): GLM
Uniswap V2 Pair Address of Token: 0xb5F790A03b7559312D9e738df5056A4b4c8459F4

Link to the official homepage of token: https://golem.network/
Link to CoinMarketCap or CoinGecko page of token: https://coinmarketcap.com/currencies/golem-network-tokens/