### PR TITLE
add new OCEAN, deprecate old one

### DIFF
--- a/src/tokens/mainnet.json
+++ b/src/tokens/mainnet.json
@@ -521,8 +521,16 @@
   },
   {
     "name": "Ocean Token",
-    "address": "0x7AFeBBB46fDb47ed17b22ed075Cde2447694fB9e",
+    "address": "0x967da4048cD07aB37855c090aAF366e4ce1b9F48",
     "symbol": "OCEAN",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x967da4048cD07aB37855c090aAF366e4ce1b9F48/logo.png"
+  },
+  {
+    "name": "Ocean Token (deprecated)",
+    "address": "0x7AFeBBB46fDb47ed17b22ed075Cde2447694fB9e",
+    "symbol": "OCEAN (deprecated)",
     "decimals": 18,
     "chainId": 1,
     "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x7AFeBBB46fDb47ed17b22ed075Cde2447694fB9e/logo.png"


### PR DESCRIPTION
Add new OCEAN contract, and deprecate old one instead of replacing it as suggested in #476. 

At [Ocean Protocol](https://oceanprotocol.com) we had to [move to a new token contract](https://blog.oceanprotocol.com/september-2020-hard-fork-ocean-token-completed-8142059361d7) following the KuCoin hack. This PR updates OCEAN to that new contract address.

Supersedes and closes #476