### PR TITLE
Adding back 0xBTC token to mainnet.json

### DIFF
--- a/src/tokens/mainnet.json
+++ b/src/tokens/mainnet.json
@@ -8,6 +8,14 @@
     "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png"
   },
   {
+    "name": "0xBitcoin Token",
+    "address": "0xB6eD7644C69416d67B522e20bC294A9a9B405B31",
+    "symbol": "0xBTC",
+    "decimals": 8,
+    "chainId": 1,
+    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xB6eD7644C69416d67B522e20bC294A9a9B405B31/logo.png"
+  },
+  {
     "name": "Dai Stablecoin",
     "address": "0x6B175474E89094C44Da98b954EedeAC495271d0F",
     "symbol": "DAI",


### PR DESCRIPTION
This is related to a recent PR that removed some tokens from the default list: https://github.com/Uniswap/default-token-list/pull/719

Change has been tested (npm test).

The reason for this pull request is that we believe the Uniswap community would benefit from keeping the 0xBTC token on the default list. We feel that Uniswap, being a decentralized platform, should be supportive of 0xBTC as it embodies decentralization as a token likely more than any other token - it is distributed purely though proof of work, there are no owners or admins, and no pre-sale / pre-mine / ICO.

We believe that a fair decentralized exchange platform like Uniswap should not remove the oldest, most established token that stands for what Uniswap stands for - decentralization.

Thank you, looking forward to chatting.
-Armen