### PR TITLE
Fix broken images and old DAI address

### DIFF
--- a/src/tokens/rinkeby.json
+++ b/src/tokens/rinkeby.json
@@ -5,15 +5,15 @@
     "symbol": "WETH",
     "decimals": 18,
     "chainId": 4,
-    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xc778417E063141139Fce010982780140Aa0cD5Ab/logo.png"
+    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png"
   },
   {
     "name": "Dai Stablecoin",
-    "address": "0xc7AD46e0b8a400Bb3C915120d284AafbA8fc4735",
+    "address": "0x5592EC0cfb4dbc12D3aB100b257153436a1f0FEa",
     "symbol": "DAI",
     "decimals": 18,
     "chainId": 4,
-    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xc7AD46e0b8a400Bb3C915120d284AafbA8fc4735/logo.png"
+    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png"
   },
   {
     "name": "Maker",
@@ -21,7 +21,7 @@
     "symbol": "MKR",
     "decimals": 18,
     "chainId": 4,
-    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xF9bA5210F91D0474bd1e1DcDAeC4C58E359AaD85/logo.png"
+    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2/logo.png"
   },
   {
     "name": "Uniswap",


### PR DESCRIPTION
This PR fixes some broken images for Rinkeby. Also uses the correct address for Rinkeby Ether. 

Is for example the one you can get in Compound faucet https://ethereum.stackexchange.com/questions/82556/how-to-obtain-rinkeby-dai