### PR TITLE
Add Token TCAP: Total Crypto Market Cap

### DIFF
--- a/src/tokens/mainnet.json
+++ b/src/tokens/mainnet.json
@@ -302,5 +302,13 @@
     "symbol": "MLN",
     "decimals": 18,
     "logoURI": "https://assets.coingecko.com/coins/images/605/thumb/melon.png?1547034295"
+  },
+  {
+    "chainId": 1,
+    "address": "0x16c52CeeCE2ed57dAd87319D91B5e3637d50aFa4",
+    "name": "Total Crypto Market Cap",
+    "symbol": "TCAP",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/14703/small/tcap.png?1617860242"
   }
 ]


### PR DESCRIPTION
Token Information

Token Address: 0x16c52CeeCE2ed57dAd87319D91B5e3637d50aFa4
Token Name (from contract): Total Crypto Market Cap
Token Decimals (from contract): 18
Token Symbol (from contract): TCAP
Uniswap V2 Pair Address of Token: 0x3436d87664964df8a1825f826f127dec13117b0b
Link to the official homepage of token: https://cryptex.finance/
Link to CoinMarketCap or CoinGecko page of token: https://www.coingecko.com/en/coins/tcap