### PR TITLE
ADD token CTX: Cryptex

### DIFF
--- a/src/tokens/mainnet.json
+++ b/src/tokens/mainnet.json
@@ -302,5 +302,13 @@
     "symbol": "MLN",
     "decimals": 18,
     "logoURI": "https://assets.coingecko.com/coins/images/605/thumb/melon.png?1547034295"
+  },
+  {
+    "chainId": 1,
+    "address": "0x321c2fe4446c7c963dc41dd58879af648838f98d",
+    "name": "Cryptex",
+    "symbol": "CTX",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/14932/small/glossy_icon_-_C200px.png?1619073171"
   }
 ]


### PR DESCRIPTION
Token information:

Token Address: 0x321c2fe4446c7c963dc41dd58879af648838f98d
Token Name (from contract): Cryptex
Token Decimals (from contract): 18
Token Symbol (from contract): CTX
Uniswap V2 Pair Address of Token: -
Link to the official homepage of token: https://cryptex.finance/
Link to CoinMarketCap or CoinGecko page of token: https://www.coingecko.com/en/coins/cryptex-finance