### PR TITLE
Add ELON: Dogelon Mars

### DIFF
--- a/src/tokens/mainnet.json
+++ b/src/tokens/mainnet.json
@@ -302,5 +302,13 @@
     "symbol": "MLN",
     "decimals": 18,
     "logoURI": "https://assets.coingecko.com/coins/images/605/thumb/melon.png?1547034295"
+  },
+  {
+    "name": "Dogelon Mars",
+    "address": "0x761d38e5ddf6ccf6cf7c55759d5210750b5d60f3",
+    "symbol": "ELON",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/ethereum/assets/0x761D38e5ddf6ccf6Cf7c55759d5210750B5D60F3/logo.png"
   }
 ]


### PR DESCRIPTION
**Token Address:** 0x761D38e5ddf6ccf6Cf7c55759d5210750B5D60F3
**Token Name (from contract):** Dogelon Mars
**Token Decimals (from contract):** 18
**Token Symbol (from contract):** ELON
**Uniswap V2 Pair Address of Token:** 0x7b73644935b8e68019ac6356c40661e1bc315860

**Link to the official homepage of token:** https://dogelonmars.com
**Link to CoinMarketCap or CoinGecko page of token:** https://coinmarketcap.com/currencies/dogelon/

**Logo:**
<img src="https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/ethereum/assets/0x761D38e5ddf6ccf6Cf7c55759d5210750B5D60F3/logo.png" alt="Dogelon Mars (ELON) logo" width="200"/>
https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/ethereum/assets/0x761D38e5ddf6ccf6Cf7c55759d5210750B5D60F3/logo.png