### PR TITLE
Add MIVA

### DIFF
--- a/src/tokens/polygon.json
+++ b/src/tokens/polygon.json
@@ -280,6 +280,14 @@
     "logoURI": "https://assets.coingecko.com/coins/images/5013/thumb/sUSD.png?1616150765"
   },
   {
+    "name": "Minerva Wallet SuperToken",
+    "address": "0xC0b2983A17573660053BEEED6FDb1053107cf387",
+    "symbol": "MIVA",
+    "decimals": 18,
+    "chainId": 137,
+    "logoURI": "https://minerva.digital/i/MIVA-Token.svg"
+  },
+  {
     "name": "Wrapped Matic",
     "address": "0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270",
     "symbol": "WMATIC",


### PR DESCRIPTION
Token Address(Polygon): 0xc0b2983a17573660053beeed6fdb1053107cf387
Token Name (from contract): Minerva Wallet SuperToken
Token Decimals (from contract): 18
Token Symbol (from contract): MIVA

Link to the official homepage of token: https://minerva.digital/
Link to CoinMarketCap or CoinGecko page of token:
https://www.coingecko.com/coins/minerva-wallet
https://coinmarketcap.com/currencies/minerva-wallet/

Note:
Token origin is on xDaiChain/GnosisChain, not Ethereum.
https://blockscout.com/xdai/mainnet/tokens/0x63e62989D9EB2d37dfDB1F93A22f063635b07d51