### PR TITLE
Add LILI: LILIUM

### DIFF
--- a/src/tokens/mainnet.json
+++ b/src/tokens/mainnet.json
@@ -326,5 +326,13 @@
     "symbol": "MATIC",
     "decimals": 18,
     "logoURI": "https://assets.coingecko.com/coins/images/4713/thumb/matic-token-icon.png?1624446912"
+  },
+  {
+    "chainId": 1,
+    "address": "2EKzQjEbEBqygpy7sqBk7E9Bj7NFsFJp9PDqqxTzVA2E",
+    "name": "lilium",
+    "symbol": "LILI",
+    "decimals": 9,
+    "logoURI": "https://raw.githubusercontent.com/hamdielhamdi/token-list/main/assets/mainnet/2EKzQjEbEBqygpy7sqBk7E9Bj7NFsFJp9PDqqxTzVA2E/lilium.png"
   }
 ]


### PR DESCRIPTION
[x ] I understand that token listing is not required to use the Uniswap Interface with a token.
[x ] I understand that filing an issue or adding liquidity does not guarantee addition to the Uniswap default token list.
[x ] I will not ping the Discord about this listing request.
Please provide the following information for your token.

Token Address: 2EKzQjEbEBqygpy7sqBk7E9Bj7NFsFJp9PDqqxTzVA2E
Token Name (from contract): LILIUM
Token Decimals (from contract): 9
Token Symbol (from contract): LILI
Uniswap V2 Pair Address of Token: 0x0000000000000000000000000000000000000000

Link to the official homepage of token: https://www.lilium-lili.com/
Link to CoinMarketCap or CoinGecko page of token: