### PR TITLE
tokens/mainnet: Add Wrapped Flow (WFLOW)

### DIFF
--- a/src/tokens/mainnet.json
+++ b/src/tokens/mainnet.json
@@ -326,5 +326,13 @@
     "symbol": "MATIC",
     "decimals": 18,
     "logoURI": "https://assets.coingecko.com/coins/images/4713/thumb/matic-token-icon.png?1624446912"
+  },
+  {
+    "chainId": 1,
+    "address": "0x5c147e74D63B1D31AA3Fd78Eb229B65161983B2b",
+    "name": "Wrapped Flow",
+    "symbol": "WFLOW",
+    "decimals": 18,
+    "logoURI": "https://raw.githubusercontent.com/wrappedfi/wrapped-logos/main/WFLOW.png"
   }
 ]


### PR DESCRIPTION
Hi friends, this PR adds Wrapped Flow (WFLOW) to the default token list. Wrapped Flow is the official wrapped version of Flow[1][2] on Ethereum.

If you all have any questions or need anything else, please don't hesitate to let us know. Thanks in advance and hope you all are doing well and are staying healthy!

Cc: @githubwei, @masonicgit

[1] https://www.coingecko.com/en/coins/flow
[2] https://flow.com/