### PR TITLE
Add Daily COP: DLYCOP

### DIFF
--- a/src/tokens/polygon.json
+++ b/src/tokens/polygon.json
@@ -286,5 +286,13 @@
     "decimals": 18,
     "chainId": 137,
     "logoURI": "https://assets.coingecko.com/coins/images/4713/thumb/matic-token-icon.png?1624446912"
+  },
+  {
+    "name": "Daily COP",
+    "address": "0x1659fFb2d40DfB1671Ac226A0D9Dcc95A774521A",
+    "symbol": "DLYCOP",
+    "decimals": 18,
+    "chainId": 137,
+    "logoURI": "https://raw.githubusercontent.com/miDaily/Daily-COP/master/logo.png"
   }
 ]


### PR DESCRIPTION
The Daily COP token is a stablecoin in Polygon that is pegged with the Colombian Peso and has over 200k users, over 2 million transactions, can be spend in Colombia in over 600 businesses and is in the top 25 in terms of liquidity in Quickswap.