### PR TITLE
Add YOP to the default token list

### DIFF
--- a/src/tokens/mainnet.json
+++ b/src/tokens/mainnet.json
@@ -1374,5 +1374,13 @@
     "symbol": "POWR",
     "decimals": 6,
     "logoURI": "https://assets.coingecko.com/coins/images/1104/thumb/power-ledger.png?1547035082"
+  },
+    {
+    "chainId": 1,
+    "address": "0xae1eaae3f627aaca434127644371b67b18444051",
+    "name": "YOP",
+    "symbol": "YOP",
+    "decimals": 8,
+    "logoURI": "https://assets.coingecko.com/coins/images/13678/small/J7zykPx.jpg?1610802162"
   }
 ]


### PR DESCRIPTION
We are currently integrating the Uniswap widget into our app and would like to use the default Uniswap token list.

Closes #1117