### PR TITLE
update list name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/default-token-list",
-  "version": "4.0.0",
+  "version": "3.2.0",
   "description": "◦ The Uniswap default token list",
   "main": "build/uniswap-default.tokenlist.json",
   "scripts": {

--- a/src/buildList.js
+++ b/src/buildList.js
@@ -11,7 +11,7 @@ const bridgeUtils = require('@uniswap/token-list-bridge-utils');
 module.exports = function buildList() {
   const parsed = version.split(".");
   const l1List = {
-    name: "Uniswap Labs Default List",
+    name: "Uniswap Labs Default",
     timestamp: new Date().toISOString(),
     version: {
       major: +parsed[0],


### PR DESCRIPTION
This PR updates the default token list name to be back to <= 20 characters in length. Even though we have updated the schema to support names up to 30 characters, there are still versions of the Uniswap widget that will not be using the updated schema and may run into errors with a name >20 chars. 

Also reverting the version update (not yet deployed) to redo the update to also include a tag. 