### PR TITLE
Adding BOB stablecoin

### DIFF
--- a/src/tokens/polygon.json
+++ b/src/tokens/polygon.json
@@ -286,5 +286,13 @@
     "decimals": 18,
     "chainId": 137,
     "logoURI": "https://assets.coingecko.com/coins/images/4713/thumb/matic-token-icon.png?1624446912"
-  }
+  },
+ {
+    "name": "BOB Token",
+    "address": "0xb0b195aefa3650a6908f15cdac7d92f8a5791b0b",
+    "symbol": "BOB",
+    "decimals": 18,
+    "chainId": 137,
+    "logoURI": "https://assets.coingecko.com/coins/images/27266/small/Bob-logo.png?1663073030"
+ }
 ]


### PR DESCRIPTION
BOB is a stablecoin fully collateralized by USDC. BOB features novel DeFi use-cases intended to generate additional yield for active participants of the Bob Protocol. BOB token is an exclusive asset for zkBob, a privacy preserving protocol for stable transfers.