### PR TITLE
build: use a later commit-tagged version of pinata action

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Pin to IPFS
         id: upload
-        uses: anantaramdas/ipfs-pinata-deploy-action@39bbda1ce1fe24c69c6f57861b8038278d53688d
+        uses: anantaramdas/ipfs-pinata-deploy-action@a551f37c17ec3961df7c3ad52e1cd266dfd3d7e7
         with:
           pin-name: Uniswap Default Token List
           path: 'build/uniswap-default.tokenlist.json'


### PR DESCRIPTION
Need to use at least this [commit]( https://github.com/popovoleksandr/ipfs-pinata-deploy-action/commit/a551f37c17ec3961df7c3ad52e1cd266dfd3d7e7) of the ipfs-pinata-deploy-action package as uploading single files is not supported until that version. 