### PR TITLE
Update SYLO token logoURI

### DIFF
--- a/src/tokens/mainnet.json
+++ b/src/tokens/mainnet.json
@@ -1771,7 +1771,7 @@
     "chainId": 1,
     "name": "Sylo",
     "symbol": "SYLO",
-    "logoURI": "https://assets.coingecko.com/coins/images/6430/thumb/SYLO.svg?1589527756",
+    "logoURI": "https://s2.coinmarketcap.com/static/img/coins/64x64/5662.png",
     "address": "0xf293d23BF2CDc05411Ca0edDD588eb1977e8dcd4",
     "decimals": 18
   },


### PR DESCRIPTION
Attempt to fix missing logo for SYLO token in live mainnet Uniswap dapp.
The logo did originally work but not currently.

Live repro: https://app.uniswap.org/#/swap?outputCurrency=0xf293d23BF2CDc05411Ca0edDD588eb1977e8dcd4

Example screenshot:
<img width="408" alt="image" src="https://user-images.githubusercontent.com/836507/193484808-75b20300-98cd-49b7-adba-8a56bb4c8b61.png">

I changed the logoURI to a coinmarketcap url, like several other tokens in the `mainnet.json` file. Hopefully this resolves the issue.

Old logoURI: https://assets.coingecko.com/coins/images/6430/thumb/SYLO.svg?1589527756
New logoURI: https://s2.coinmarketcap.com/static/img/coins/64x64/5662.png

Open to any feedback or suggestions.

Cheers.