### PR TITLE
Adding BOB stablecoin to mainnet token list

### DIFF
--- a/src/tokens/mainnet.json
+++ b/src/tokens/mainnet.json
@@ -1854,5 +1854,13 @@
     "logoURI": "https://assets.coingecko.com/coins/images/17358/thumb/le1nzlO6_400x400.jpg?1632465691",
     "address": "0x25f8087EAD173b73D6e8B84329989A8eEA16CF73",
     "decimals": 18
+  },
+  {
+    "chainId": 1,
+    "name": "BOB Token",
+    "symbol": "BOB",
+    "logoURI": "https://assets.coingecko.com/coins/images/27266/small/Bob-logo.png?1663073030",
+    "address": "0xb0b195aefa3650a6908f15cdac7d92f8a5791b0b",
+    "decimals": 18
   }
 ]


### PR DESCRIPTION
BOB is a stablecoin fully collateralized by USDC. BOB features novel DeFi use-cases intended to generate additional yield for active participants of the Bob Protocol. BOB token is an exclusive asset for zkBob, a privacy preserving protocol for stable transfers. 

Token Address: 0xb0b195aefa3650a6908f15cdac7d92f8a5791b0b https://etherscan.io/token/0xB0B195aEFA3650A6908f15CdaC7D92F8a5791B0B Token Name: BOB
Token Decimals: 18
Token Symbol: BOB
Uniswap pool: https://info.uniswap.org/#/pools/0x8fb60298c6bbafa428494fd2d63d116063ef32e2

Link to the official homepage of token: https://www.zkbob.com/ Documentation: https://docs.zkbob.com/
Link to CoinMarketCap or CoinGecko page of token: https://www.coingecko.com/en/coins/bob; https://coinmarketcap.com/currencies/bob/

Logo:
https://assets.coingecko.com/coins/images/27266/small/Bob-logo.png?1663073030