### PR TITLE
Add CELO and some L2 Mappings

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@ethersproject/address": "^5.0.2",
     "@uniswap/token-lists": "^1.0.0-beta.29",
-    "@uniswap/token-list-bridge-utils": "^1.0.8",
+    "@uniswap/token-list-bridge-utils": "1.1.0",
     "ajv": "^6.12.3",
     "chai": "^4.2.0",
     "mocha": "^8.0.1",

--- a/src/buildList.js
+++ b/src/buildList.js
@@ -7,6 +7,7 @@ const kovan = require("./tokens/kovan.json");
 const polygon = require("./tokens/polygon.json");
 const mumbai = require("./tokens/mumbai.json");
 const optimism = require("./tokens/optimism.json");
+const celo = require("./tokens/celo.json");
 const bridgeUtils = require('@uniswap/token-list-bridge-utils');
 
 module.exports = function buildList() {
@@ -22,7 +23,7 @@ module.exports = function buildList() {
     tags: {},
     logoURI: "ipfs://QmNa8mQkrNKp1WEEeGjFezDmDeodkWRevGFN8JCV7b4Xir",
     keywords: ["uniswap", "default"],
-    tokens: [...mainnet, ...ropsten, ...goerli, ...kovan, ...rinkeby, ...polygon, ...mumbai, ...optimism]
+    tokens: [...mainnet, ...ropsten, ...goerli, ...kovan, ...rinkeby, ...polygon, ...mumbai, ...optimism, ...celo]
       // sort them by symbol for easy readability
       .sort((t1, t2) => {
         if (t1.chainId === t2.chainId) {

--- a/src/tokens/celo.json
+++ b/src/tokens/celo.json
@@ -1,0 +1,10 @@
+[
+    {
+      "chainId": 42220,
+      "address": "0x471EcE3750Da237f93B8E339c536989b8978a438",
+      "name": "Celo",
+      "symbol": "CELO",
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/ubeswap/default-token-list/master/assets/asset_CELO.png"
+    }
+  ]

--- a/src/tokens/mainnet.json
+++ b/src/tokens/mainnet.json
@@ -5,7 +5,23 @@
     "symbol": "WETH",
     "decimals": 18,
     "chainId": 1,
-    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png"
+    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
+    "extensions": {
+      "bridgeInfo": {
+        "10": {
+          "tokenAddress": "0x4200000000000000000000000000000000000006"
+        },
+        "42161": {
+          "tokenAddress": "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1"
+        },
+        "137": {
+          "tokenAddress": "0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619"
+        },
+        "42220": {
+          "tokenAddress": "0x2DEf4285787d58a2f811AF24755A8150622f4361"
+        }
+      }
+    }
   },
   {
     "name": "Dai Stablecoin",
@@ -189,7 +205,14 @@
     "name": "Aave",
     "symbol": "AAVE",
     "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/12645/thumb/AAVE.png?1601374110"
+    "logoURI": "https://assets.coingecko.com/coins/images/12645/thumb/AAVE.png?1601374110",
+    "extensions": {
+      "bridgeInfo": {
+        "10": {
+          "tokenAddress": "0x76FB31fb4af56892A25e32cFC43De717950c9278"
+        }
+      }
+    }
   },
   {
     "chainId": 1,
@@ -325,7 +348,14 @@
     "name": "Polygon",
     "symbol": "MATIC",
     "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/4713/thumb/matic-token-icon.png?1624446912"
+    "logoURI": "https://assets.coingecko.com/coins/images/4713/thumb/matic-token-icon.png?1624446912",
+    "extensions": {
+      "bridgeInfo": {
+        "137": {
+          "tokenAddress": "0x0000000000000000000000000000000000001010"
+        }
+      }
+    }
   },
   {
     "chainId": 1,

--- a/yarn.lock
+++ b/yarn.lock
@@ -534,10 +534,10 @@
     tiny-invariant "^1.1.0"
     toformat "^2.0.0"
 
-"@uniswap/token-list-bridge-utils@^1.0.8":
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/@uniswap/token-list-bridge-utils/-/token-list-bridge-utils-1.0.8.tgz#cf3e79a009a80e42808360d13c79125ec6492df6"
-  integrity sha512-W6HR2N40IJK5Td7yqm7JguydT0iv2CAUws5eMaPTEurAl/LFBsaLPD/XAhyPfG6ShucQGWDWXuzEq9WG4vv+1Q==
+"@uniswap/token-list-bridge-utils@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@uniswap/token-list-bridge-utils/-/token-list-bridge-utils-1.1.0.tgz#24bb12464f19106278260ab78612cc6a83ebaf5f"
+  integrity sha512-eJrPMLiMjd4NHJxMwdADw2Vhi2/qnJDJg8j+o5BjNsebINv0v8IjhntKh48jMm4+UNxKSAZe8qcaT+uq0Dv+5A==
   dependencies:
     "@arbitrum/sdk" "^1.1.4"
     "@uniswap/sdk-core" "^3.0.1"
@@ -545,6 +545,7 @@
     dotenv "^16.0.1"
     ethers "^5.6.5"
     lodash "^4.17.21"
+    prettier "^2.7.1"
     web3 "^1.7.3"
 
 "@uniswap/token-lists@^1.0.0-beta.29":
@@ -2866,6 +2867,11 @@ prettier@^2.1.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.6.2.tgz#e26d71a18a74c3d0f0597f55f01fb6c06c206032"
   integrity sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==
+
+prettier@^2.7.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.7.1.tgz#e235806850d057f97bb08368a4f7d899f7760c64"
+  integrity sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==
 
 process@^0.11.10:
   version "0.11.10"


### PR DESCRIPTION
This PR upgrades to the latest version of token-list-bridge-utils [library](https://github.com/Uniswap/token-list-bridge-utils), which now allows us to add L2 bridgeInfo mappings to the initial L1 list directly, and those mappings will be maintained in the final outputted list. The library will still automatically append a root-level token entry for the manually added L2 addresses. This now lets us manually add mappings that the library may be unable to fetch, increasing the coverage of our L2 mappings. 

- also adds CELO token to the default list. 
- adds some manual mappings (AAVE on optimism, WETH on all uniswap-supported chains, MATIC on polygon)
