### PR TITLE
update tBTC

### DIFF
--- a/src/tokens/mainnet.json
+++ b/src/tokens/mainnet.json
@@ -312,11 +312,11 @@
   },
   {
     "chainId": 1,
-    "address": "0x8dAEBADE922dF735c38C80C7eBD708Af50815fAa",
+    "address": "0x18084fbA666a33d37592fA2633fD49a74DD93a88",
     "name": "tBTC",
-    "symbol": "TBTC",
+    "symbol": "tBTC",
     "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/11224/thumb/tBTC.png?1589620754"
+    "logoURI": "https://raw.githubusercontent.com/uniswap/assets/master/blockchains/ethereum/assets/0x18084fbA666a33d37592fA2633fD49a74DD93a88/logo.png"
   },
   {
     "chainId": 1,

--- a/src/tokens/polygon.json
+++ b/src/tokens/polygon.json
@@ -257,14 +257,6 @@
   },
   {
     "chainId": 137,
-    "address": "0x50a4a434247089848991DD8f09b889D4e2870aB6",
-    "name": "tBTC",
-    "symbol": "TBTC",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/11224/thumb/tBTC.png?1589620754"
-  },
-  {
-    "chainId": 137,
     "address": "0xbD7A5Cf51d22930B8B3Df6d834F9BCEf90EE7c4f",
     "name": "Ethereum Name Service",
     "symbol": "ENS",


### PR DESCRIPTION
- updates deprecated tBTC address to new tBTC v2 address: https://etherscan.io/token/0x18084fbA666a33d37592fA2633fD49a74DD93a88

- updates logo to https://raw.githubusercontent.com/uniswap/assets/master/blockchains/ethereum/assets/0x18084fbA666a33d37592fA2633fD49a74DD93a88/logo.png

- removes polygon entry since that was bridged from the deprecated contract.