### PR TITLE
bump token-list-bridge-utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@ethersproject/address": "^5.0.2",
     "@uniswap/token-lists": "^1.0.0-beta.29",
-    "@uniswap/token-list-bridge-utils": "^1.3.2",
+    "@uniswap/token-list-bridge-utils": "^1.3.3",
     "ajv": "^6.12.3",
     "chai": "^4.2.0",
     "mocha": "^8.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -534,10 +534,10 @@
     tiny-invariant "^1.1.0"
     toformat "^2.0.0"
 
-"@uniswap/token-list-bridge-utils@^1.3.2":
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/@uniswap/token-list-bridge-utils/-/token-list-bridge-utils-1.3.2.tgz#2fe22ab9c12c9e5732be4837c55be3148fe1c0d3"
-  integrity sha512-7v+1ZWxvOD70ZdLpNRps8rVPcn5xL7QdmPHCqKQv5HzI8tjBfmvqIIdIyKnsDBE8qAfp0VbFTQWVs6B3sCWjeQ==
+"@uniswap/token-list-bridge-utils@^1.3.3":
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/@uniswap/token-list-bridge-utils/-/token-list-bridge-utils-1.3.3.tgz#dabac008d52aa2a7b34eaa723a2ea01f10f80973"
+  integrity sha512-8sQsAxnq0GbBqBpyd1Xul72n1b/00lI3NtknCig4pj1v7JvD4Wke1TNAzjmJDsBoMVcz7LTa4eEow0SXdNa8kw==
   dependencies:
     "@arbitrum/sdk" "^1.1.4"
     "@uniswap/sdk-core" "^3.0.1"


### PR DESCRIPTION
bumping to latest version of token-list-bridge-utils package, which uses a more reliable public mainnet RPC node.