### PR TITLE
Add pysud and gmx

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/default-token-list",
-  "version": "11.5.0",
+  "version": "11.6.0",
   "description": "The Uniswap default token list",
   "main": "build/uniswap-default.tokenlist.json",
   "scripts": {

--- a/src/tokens/arbitrum.json
+++ b/src/tokens/arbitrum.json
@@ -6,5 +6,13 @@
     "decimals": 6,
     "chainId": 42161,
     "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png"
+  },
+  {
+    "name": "GMX",
+    "address": "0xfc5A1A6EB076a2C7aD06eD22C90d7E710E35ad0a",
+    "symbol": "GMX",
+    "decimals": 18,
+    "chainId": 42161,
+    "logoURI": "https://assets.coingecko.com/coins/images/18323/large/arbit.png?1631532468"
   }
 ]

--- a/src/tokens/avalanche.json
+++ b/src/tokens/avalanche.json
@@ -30,5 +30,13 @@
       "symbol": "UNI.e",
       "decimals": 18,
       "logoURI": "https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/avalanchec/assets/0x8eBAf22B6F053dFFeaf46f4Dd9eFA95D89ba8580/logo.png"
+    },
+    {
+      "chainId": 43114,
+      "address": "0x62edc0692BD897D2295872a9FFCac5425011c661",
+      "name": "GMX",
+      "symbol": "GMX",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/18323/large/arbit.png?1631532468"
     }
   ]

--- a/src/tokens/mainnet.json
+++ b/src/tokens/mainnet.json
@@ -1977,5 +1977,13 @@
     "symbol": "PRIME",
     "decimals": 18,
     "logoURI": "https://assets.coingecko.com/coins/images/29053/large/PRIMELOGOOO.png?1676976222"
+  },
+  {
+    "chainId": 1,
+    "address": "0x6c3ea9036406852006290770BEdFcAbA0e23A0e8",
+    "name": "PayPal USD",
+    "symbol": "PYUSD",
+    "decimals": 6,
+    "logoURI": "https://assets.coingecko.com/coins/images/31212/large/PYUSD_Logo_%282%29.png?1691458314"
   }
 ]


### PR DESCRIPTION
We want to add PYUSD and GMX.

Slack context: https://uniswapteam.slack.com/archives/C014WRW57NJ/p1694013772695749

PyUSD: https://etherscan.io/token/0x6c3ea9036406852006290770BEdFcAbA0e23A0e8
GMX: https://arbiscan.io/token/0xfc5A1A6EB076a2C7aD06eD22C90d7E710E35ad0a

@cgkol @just-toby @mzywang PTAL? Thanks!