### PR TITLE
add a8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/default-token-list",
-  "version": "12.5.0",
+  "version": "12.6.0",
   "description": "The Uniswap default token list",
   "main": "build/uniswap-default.tokenlist.json",
   "scripts": {

--- a/src/tokens/mainnet.json
+++ b/src/tokens/mainnet.json
@@ -2171,7 +2171,14 @@
     "name": "LayerZero",
     "symbol": "ZRO",
     "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/28206/standard/ftxG9_TJ_400x400.jpeg?1696527208"
+    "logoURI": "https://assets.coingecko.com/coins/images/28206/standard/ftxG9_TJ_400x400.jpeg?1696527208",
+    "extensions": {
+      "bridgeInfo": {
+        "42161": {
+          "tokenAddress": "0x6985884C4392D348587B19cb9eAAf157F13271cd"
+        }
+      }
+    }
   },
   {
     "chainId": 1,

--- a/src/tokens/mainnet.json
+++ b/src/tokens/mainnet.json
@@ -2217,5 +2217,13 @@
     "symbol": "REZ",
     "decimals": 18,
     "logoURI": "https://assets.coingecko.com/coins/images/37327/standard/renzo_200x200.png?1714025012"
+  },
+  {
+    "chainId": 1,
+    "address": "0x3E5A19c91266aD8cE2477B91585d1856B84062dF",
+    "name": "Ancient8",
+    "symbol": "A8",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/39170/standard/A8_Token-04_200x200.png?1720798300"
   }
 ]


### PR DESCRIPTION
adds a8 (Ancient8)  token. 

also fixes newly failing unit test due to our token-list-bridge-util pulling a seemingly unofficial/duplicate [ARB LayerZero](https://arbiscan.io/address/0xd99f14023f6Bde3142D339b6C069b2B711dA7e37) by setting a bridgeInfo override for the [official one](https://arbiscan.io/address/0x6985884C4392D348587B19cb9eAAf157F13271cd) that is on the existing default list. 