### PR TITLE
Add THAT Token

### DIFF
--- a/src/tokens/polygon.json
+++ b/src/tokens/polygon.json
@@ -302,5 +302,13 @@
     "symbol": "ZRO",
     "decimals": 18,
     "logoURI": "https://assets.coingecko.com/coins/images/28206/standard/ftxG9_TJ_400x400.jpeg?1696527208"
+  },
+  {
+    "chainId": 137,
+    "address": "0xd2e57e7019a8faea8b3e4a3738ee5b269975008a",
+    "name": "THAT",
+    "symbol": "THAT",
+    "decimals": 18,
+    "logoURI": "https://raw.githubusercontent.com/THAT-Global/brand-assets/4517783608b6b66acc87bd1bf43f56136ad42e4d/that.svg"
   }
 ]


### PR DESCRIPTION
Chain: Polygon
Token Address: 0xd2e57e7019a8faea8b3e4a3738ee5b269975008a
Token Name (from contract): THAT
Token Decimals (from contract): 18
Token Symbol (from contract): THAT
Uniswap V3 Pair Address of Token: [0x5ce1bbbfb735e8e7d2afd8e0b3fb288771255ab2](https://app.uniswap.org/explore/pools/polygon/0x5ce1bbbfb735e8e7d2afd8e0b3fb288771255ab2)

Link to the official homepage of token: [https://that.website](https://that.website)