### PR TITLE
Add GMIX Token

### DIFF
--- a/src/tokens/polygon.json
+++ b/src/tokens/polygon.json
@@ -302,5 +302,13 @@
     "symbol": "ZRO",
     "decimals": 18,
     "logoURI": "https://assets.coingecko.com/coins/images/28206/standard/ftxG9_TJ_400x400.jpeg?1696527208"
+  },
+  {
+    "chainId": 137,
+    "address": "0x5a3999445d4cb78b8560b9083eee7db56f9f046e",
+    "name": "GMIX",
+    "symbol": "GMIX",
+    "decimals": 18,
+    "logoURI": "https://www.gmix.io/logogmix.png"
   }
 ]


### PR DESCRIPTION
Link #1891 

Token Address: 0x5a3999445d4cb78b8560b9083eee7db56f9f046e
Token Name (from contract): GMIX
Token Decimals (from contract): 18
Link to the official homepage of token: https://www.gmix.io/