### PR TITLE
Added token metadata for DOG meme coin ($DOG) to mainnet.json

### DIFF
--- a/src/tokens/mainnet.json
+++ b/src/tokens/mainnet.json
@@ -2432,5 +2432,13 @@
     "symbol": "USDQ",
     "decimals": 6,
     "logoURI": "https://coin-images.coingecko.com/coins/images/51852/large/USDQ_1000px_Color.png?1732071232"
+  },
+  {
+     "chainId": 1,
+     "address": "0x131c1d2eef8c4fd641a0ea487dadcf33371346dd",
+     "name": "DOG",
+     "symbol": "$DOG",
+     "decimals": 18,
+     "logoURI": "https://whalememe.github.io/uniswap-logos/0x131c1d2eef8c4fd641a0ea487dadcf33371346dd.png"
   }
 ]


### PR DESCRIPTION
This PR adds the metadata for the $DOG token to the Ethereum mainnet token list. 

**Details:**
- **Token address**: 0x131c1d2eef8c4fd641a0ea487dadcf33371346dd
- **Token symbol**: $DOG
- **Token decimals**: 18
- **Logo URI**: https://whalememe.github.io/uniswap-logos/0x131c1d2eef8c4fd641a0ea487dadcf33371346dd.png

The updated `mainnet.json` has been validated and adheres to the token list schema.
