### PR TITLE
Add SCRATCH to the token list.

### DIFF
--- a/src/tokens/mainnet.json
+++ b/src/tokens/mainnet.json
@@ -2473,4 +2473,15 @@
     "decimals": 8,
     "logoURI": "https://coin-images.coingecko.com/coins/images/31401/large/sticker_(1).jpg?1702371083"
   }
+  {
+    "chainId": 1,
+    "address": "0x2fA39203cb335d08E0Af7731a8B9ae23d5a59449",
+    "name": "$SCRATCH",
+    "symbol": "$SCRATCH",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/52943/standard/scratch200trans.png?1734768772"
+  }
+
+
+
 ]


### PR DESCRIPTION
$SCRATCH on Mainnet is a token that was created by a fully doxxed and very transparent team. The UNRUGGABLES. The UNRUGGABLES are a team and community on Crypto Twitter that stand for transparency and honesty in web3, and $SCRATCH is their project. The project has multiple gamefi integrations on the way, and has a very serious and substantial LP. Multiple large investors on board have no interest in doing away with this project at any point, and it is here for the long haul.