### PR TITLE
test: add validation for token decimals

### DIFF
--- a/test/uniswap-default.test.js
+++ b/test/uniswap-default.test.js
@@ -68,4 +68,12 @@ describe('buildList', () => {
     expect(packageJson.version).to.match(/^\d+\.\d+\.\d+$/);
     expect(packageJson.version).to.equal(`${defaultTokenList.version.major}.${defaultTokenList.version.minor}.${defaultTokenList.version.patch}`);
   });
+
+  it('all tokens have valid decimals', () => {
+    for (let token of defaultTokenList.tokens) {
+      expect(token.decimals).to.be.a('number');
+      expect(token.decimals).to.be.gte(0);
+      expect(token.decimals).to.be.lte(18);
+    }
+  });
 });


### PR DESCRIPTION
Add a new test case to validate that all tokens in the list have proper decimal values. This ensures that:
- decimals are numbers
- decimals are non-negative
- decimals do not exceed 18 (standard ERC20 maximum)

This validation helps prevent issues with token display and calculations in the Uniswap interface.