### PR TITLE
feat: remove deprecated Ethereum test network

### DIFF
--- a/src/buildList.js
+++ b/src/buildList.js
@@ -1,9 +1,6 @@
 const { version } = require("../package.json");
 const mainnet = require("./tokens/mainnet.json");
-const ropsten = require("./tokens/ropsten.json");
-const rinkeby = require("./tokens/rinkeby.json");
 const goerli = require("./tokens/goerli.json");
-const kovan = require("./tokens/kovan.json");
 const polygon = require("./tokens/polygon.json");
 const mumbai = require("./tokens/mumbai.json");
 const optimism = require("./tokens/optimism.json");
@@ -34,10 +31,7 @@ module.exports = function buildList() {
     keywords: ["uniswap", "default"],
     tokens: [
       ...mainnet,
-      ...ropsten,
       ...goerli,
-      ...kovan,
-      ...rinkeby,
       ...polygon,
       ...mumbai,
       ...optimism,


### PR DESCRIPTION
Remove Ropsten, Rinkeby, and Kovan networks from the token list as they are no longer supported by Ethereum. This change helps maintain the list up-to-date and reduces confusion for users by only including active test networks (Goerli and Sepolia).