### PR TITLE
Add AiFrUiT unicorn (ref. AiFrUiT NFT)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/default-token-list",
-  "version": "13.29.0",
+  "version": "13.30.0",
   "description": "The Uniswap default token list",
   "main": "build/uniswap-default.tokenlist.json",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/default-token-list",
-  "version": "13.31.0",
+  "version": "13.32.0",
   "description": "The Uniswap default token list",
   "main": "build/uniswap-default.tokenlist.json",
   "scripts": {

--- a/src/tokens/blast.json
+++ b/src/tokens/blast.json
@@ -6,5 +6,13 @@
     "symbol": "BLAST",
     "decimals": 18,
     "logoURI": "https://assets.coingecko.com/coins/images/35494/standard/Blast.jpg?1719385662"
+  },
+  {
+    "chainId": 81457,
+    "address": "0x092D76d6603543a5e604Ee388e50CAa3a46E4dbD",
+    "name": "AiFrUiT unicorn",
+    "symbol": "AIUNI",
+    "decimals": 18,
+    "logoURI": "https://aifruit.org/AIUNI.jpg"
   }
 ]


### PR DESCRIPTION
Please consider adding AiFrUiT unicorn (AIUNI) to the official Uniswap Token List. Issued by the well-established AiFrUiT NFT team, AIUNI is a fully ERC-20–compliant utility token whose contract is verified on the official Blastscan.io and whose fixed supply is transparently auditable. The token underpins an active ecosystem of hundreds of NFT holders on multiple chains, and has its own planned chain, featured by multiple leading NFT marketplaces. Its audit, made by OpenZeppelin Security reports confidence, and the project operates under very clear policies. It makes a low-risk and high-utility addition to Uniswap interfaces. Listing AIUNI will improve discoverability for Uniswap on Blast, while reinforcing the protocol’s reputation for fostering innovative, socially responsible digital assets.