### PR TITLE
Add XiPower (XIP) token to mainnet token list

### DIFF
--- a/XiPower
+++ b/XiPower
@@ -1,0 +1,20 @@
+{
+  "name": "XiPower Token List",
+  "timestamp": "2025-05-05T15:00:00+00:00",
+  "version": {
+    "major": 1,
+    "minor": 0,
+    "patch": 0
+  },
+  "tokens": [
+    {
+      "chainId": 1,
+      "address": "0xeA6ca78406074A70139227D9F006f9f6C9cA934C",
+      "name": "XiPower",
+      "symbol": "XIP",
+      "decimals": 18,
+      "logoURI": "ipfs://bafkreih7wzbp7rcui2afursgokcp3am3skb3n7rugouwoo2k737wckelfe"
+    }
+  ],
+  "keywords": ["meme", "experimental"]
+}

--- a/src/tokens/mainnet.json
+++ b/src/tokens/mainnet.json
@@ -2608,5 +2608,13 @@
     "symbol": "CORN",
     "decimals": 18,
     "logoURI": "https://coin-images.coingecko.com/coins/images/54471/large/corn.jpg?1739933588"
-  }
-]
+    },
+    {
+      "chainId": 1,
+      "address": "0x9Ee493dFe96fD431891137Ff3Aa12D0142fcA078",
+      "name": "XiPower",
+      "symbol": "XIP",
+      "decimals": 18,
+      "logoURI": "https://gateway.pinata.cloud/ipfs/bafkreih7wzbp7rcui2afursgokcp3am3skb3n7rugouwoo2k737wckelfe"
+    }
+  ]


### PR DESCRIPTION
This pull request adds the XiPower (XIP) token to the Uniswap default token list.

- Token Address: 0xeA6ca78406074A70139227D9F006f9f6C9cA934C
- Chain ID: 1 (Ethereum Mainnet)
- Decimals: 18
- Logo URI (IPFS): ipfs://bafkreih7wzbp7rcui2afursgokcp3am3skb3n7ruguowoo2k737wckelfe
- Symbol: XIP
- Name: XiPower

This is an experimental meme token with a fair launch and no presale.
