### PR TITLE
Add suq token

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/default-token-list",
-  "version": "13.34.0",
+  "version": "13.35.0",
   "description": "The Uniswap default token list",
   "main": "build/uniswap-default.tokenlist.json",
   "scripts": {

--- a/src/tokens/mainnet.json
+++ b/src/tokens/mainnet.json
@@ -2632,5 +2632,13 @@
     "symbol": "SXT",
     "decimals": 18,
     "logoURI": "https://coin-images.coingecko.com/coins/images/55424/large/sxt-token_circle.jpg?1745935919"
+  },
+  {
+    "chainId": 1,
+    "address": "0x7F523bD960301Dd60c1865cd9FEC5B1Ec42beae2",
+    "name": "SUQ",
+    "symbol": "SUQ",
+    "decimals": 18,
+    "logoURI": "https://suqx.live/images/logo-256.png"
   }
 ]

--- a/tokenlist.json
+++ b/tokenlist.json
@@ -1,0 +1,26 @@
+{
+  "name": "SUQ Token List",
+  "logoURI": "https://suqx.live/images/logo-256.png",
+  "timestamp": "2025-05-20T12:00:00+00:00",
+  "version": { "major": 1, "minor": 0, "patch": 1 },
+  "keywords": ["SUQ", "Halal", "Shariah", "Charity"],
+  "tokens": [
+    {
+      "chainId": 1,
+      "address": "0x7F523bD960301Dd60c1865cd9FEC5B1Ec42beae2",
+      "symbol": "SUQ",
+      "name": "Souq",
+      "decimals": 18,
+      "logoURI": "https://suqx.live/images/logo-256.png",
+      "tags": ["Charity", "Halal"],
+      "extensions": {
+        "website": "https://suq.finance",
+        "description": "SUQ is a Shariah-compliant ERC-20 token with built-in charity and team vesting.",
+        "coingeckoId": "suq",
+        "twitter": "https://twitter.com/SUQ_Official",
+        "telegram": "https://t.me/+fWL21DQzrN03YzJk",
+        "discord": "https://discord.gg/p8Zedxz7c2"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds SUQ (0x7F523bD960301Dd60c1865cd9FEC5B1Ec42beae2) to the mainnet token list,
bumping version to 1.0.1. Logo hosted at https://suqx.live/images/logo-256.png.
