### PR TITLE
Update polygon.json

### DIFF
--- a/src/tokens/polygon.json
+++ b/src/tokens/polygon.json
@@ -310,5 +310,14 @@
     "symbol": "VANRY",
     "decimals": 18,
     "logoURI": "https://coin-images.coingecko.com/coins/images/33466/large/apple-touch-icon.png?1701942541"
+  },
+  {
+    "chainId": 137,
+    "address": "0x84eBc138F4Ab844A3050a6059763D269dC9951c6",
+    "name": "Fishcake Coin Chain",
+    "symbol": "FCC",
+    "decimals": 6,
+    "logoURI": "https://github.com/Fishcake-Labs/image-/blob/96f727a940723045cbdfe67110b3a05dcfb4bfe7/FCC%20Icon-256x256.png"
   }
+
 ]


### PR DESCRIPTION
Summary: Add Fishcake Coin (FCC) token to mainnet list
Description: FCC is the utility token of the Fishcake Web3 EventFi platform.