### PR TITLE
Add Fishcake Coin (FCC) Token for Uniswap Default Token List

### DIFF
--- a/src/tokens/polygon.json
+++ b/src/tokens/polygon.json
@@ -310,5 +310,14 @@
     "symbol": "VANRY",
     "decimals": 18,
     "logoURI": "https://coin-images.coingecko.com/coins/images/33466/large/apple-touch-icon.png?1701942541"
+  },
+  {
+    "chainId": 137,
+    "address": "0x84eBc138F4Ab844A3050a6059763D269dC9951c6",
+    "name": "Fishcake Coin Chain",
+    "symbol": "FCC",
+    "decimals": 6,
+    "logoURI": "https://github.com/Fishcake-Labs/image-/blob/96f727a940723045cbdfe67110b3a05dcfb4bfe7/FCC%20Icon-256x256.png"
   }
+
 ]

--- a/src/tokens/polygon.json
+++ b/src/tokens/polygon.json
@@ -314,7 +314,7 @@
   {
     "chainId": 137,
     "address": "0x84eBc138F4Ab844A3050a6059763D269dC9951c6",
-    "name": "Fishcake Coin Chain",
+    "name": "Fishcake Coin",
     "symbol": "FCC",
     "decimals": 6,
     "logoURI": "https://github.com/Fishcake-Labs/image-/blob/96f727a940723045cbdfe67110b3a05dcfb4bfe7/FCC%20Icon-256x256.png"


### PR DESCRIPTION
## Summary

Adding Fishcake Coin (FCC), a utility token powering Fishcake Web3 EventFi ecosystem for tokenized campaigns and reward distribution.

## Project Info
- Website: https://www.fishcake.org
- dApp: https://www.fishcake.io
- Twitter: https://twitter.com/fishcake_labs
- Telegram: https://t.me/fishcake_official
- Token Address: 0x84eBc138F4Ab844A3050a6059763D269dC9951c6
- Chain: Polygon (chainId: 137)
- Decimals: 6

## Checklist
- [x] Token deployed and verified on Polygon
- [x] Transparent logo (256x256) hosted at a public link
- [x] Project has active community and use case
