### PR TITLE
Add BVLT to Polygon polygon.json

### DIFF
--- a/src/tokens/polygon.json
+++ b/src/tokens/polygon.json
@@ -310,5 +310,13 @@
     "symbol": "VANRY",
     "decimals": 18,
     "logoURI": "https://coin-images.coingecko.com/coins/images/33466/large/apple-touch-icon.png?1701942541"
+  },
+  {
+    "chainId": 137,
+    "address": "0xf0c3DAEf1B08e91a2DD00Cf36a8FfE38fEf270d1",
+    "name": "Black Vault",
+    "symbol": "BVLT",
+    "decimals": 18,
+    "logoURI": "https://raw.githubusercontent.com/Glab-74/Black-Vault-Token/main/logo_black_vault.png"
   }
 ]


### PR DESCRIPTION
This pull request adds the Black Vault token to the Uniswap token list.
The token details include the contract address, symbol (BVLT), decimals (18), and a logo hosted on GitHub.
This token is intended for use in crypto ETF creation and liquidity pools.

Please review and consider merging. Thank you!