### PR TITLE
feat: add Ratio1 token list

### DIFF
--- a/ratio1.tokenlist.json
+++ b/ratio1.tokenlist.json
@@ -1,0 +1,20 @@
+{
+  "name": "Ratio1 Token List",
+  "timestamp": "2025-10-06T00:00:00+00:00",
+  "version": {
+    "major": 1,
+    "minor": 0,
+    "patch": 0
+  },
+  "tokens": [
+    {
+      "chainId": 8453,
+      "address": "0x6444c6c2d527d85ea97032da9a7504d6d1448ecf",
+      "symbol": "R1",
+      "name": "Ratio1",
+      "decimals": 18,
+      "logoURI": "https://res.cloudinary.com/djcbjwqlc/image/upload/v1738940106/TokenR1.png"
+    }
+  ]
+}
+


### PR DESCRIPTION
Added: Ratio1 Token List

This PR adds the official token list for the Ratio1 project and R1 token deployed on Base Mainnet (chainId 8453).

Hosted raw list:
https://raw.githubusercontent.com/Ratio1/token-list/refs/heads/main/ratio1-tokenlist.json

Token logo:
https://res.cloudinary.com/djcbjwqlc/image/upload/v1738940106/TokenR1.png

Project website:
https://ratio1.ai

Token metadata and logo have been validated.
