### PR TITLE
Add Lemonzi token to Base token list

### DIFF
--- a/src/tokens/base.json
+++ b/src/tokens/base.json
@@ -302,7 +302,7 @@
     "symbol": "cbADA",
     "decimals": 6,
     "logoURI": "https://coin-images.coingecko.com/coins/images/66647/large/Coinbase_Wrapped_Ada_%28cbADA%29.png?1750129533"
-  }
+  },
   {
     "chainId": 8453,
     "address": "0x15023B82731d4C5889d93052261a97A45B71Fcc7",


### PR DESCRIPTION
This PR adds the Lemonzi (LOZI) token on Base network with its logo and details