### PR TITLE
Add XCOIN (XTH) – verified contract, PNG logo and renounced ownership

### DIFF
--- a/src/tokens/mainnet.json
+++ b/src/tokens/mainnet.json
@@ -2696,5 +2696,13 @@
     "symbol": "PROVE",
     "decimals": 18,
     "logoURI": "https://coin-images.coingecko.com/coins/images/67905/large/succinct-logo.png?1754228574"
-  }
+  },
+  {
+  "chainId": 1,
+  "address": "0x4e072E18387FDc4C5768b0a99d5FABc5a28F7296",
+  "name": "XCOIN",
+  "symbol": "XTH",
+  "decimals": 18,
+  "logoURI": "https://xcoineth.com/LogoXoin.svg"
+}
 ]


### PR DESCRIPTION
Contract: 0x4e072E18387FDc4C5768b0a99d5FABc5a28F7296 (chainId 1, decimals 18)
Symbol/Name: XTH / XCOIN
logoURI: https://xcoineth.com/logo.png (PNG, public)
Evidence:
Etherscan (contract verified)
Ownership renounced (owner = 0x000…000)
0% buy/sell taxes
Active trading on Uniswap + SushiSwap
Blockaid false-positive corrected
Official:
Website: https://xcoineth.com
X/Twitter: https://x.com/xcoin_xth