### PR TITLE
Add ARMT token (ArmenianToken) to Ethereum mainnet token list

### DIFF
--- a/src/tokens/mainnet.json
+++ b/src/tokens/mainnet.json
@@ -2719,6 +2719,6 @@
     "name": "ArmenianToken",
     "symbol": "ARMT",
     "decimals": 18,
-    "logoURI": "https://raw.githubusercontent.com/SBagratyan/token-lists/main/src/tokens/armt-logo.png"
+    "logoURI": "https://raw.githubusercontent.com/SBagratyan/armt-tokenlist/main/0xC70318bd0659528Dbf672298e385445a534A5B07.png"
   }
 ]


### PR DESCRIPTION
### Token Information
- Name: ArmenianToken
- Symbol: ARMT
- Contract Address: 0xC70318bd0659528Dbf672298e385445a534A5B07
- Chain ID: 1 (Ethereum mainnet)
- Decimals: 18
- Etherscan: https://etherscan.io/token/0xC70318bd0659528Dbf672298e385445a534A5B07
- Logo: 256x256 PNG

This PR adds the ARMT token to the Uniswap default token list for automatic detection on the Uniswap interface.
