### PR TITLE
Update base.json

### DIFF
--- a/src/tokens/base.json
+++ b/src/tokens/base.json
@@ -366,5 +366,13 @@
     "symbol": "FLOCK",
     "decimals": 18,
     "logoURI": "https://coin-images.coingecko.com/coins/images/53178/large/FLock_Token_Logo.png?1735561398"
-  }
+  },
+{
+"chainId": 8453,
+"address": "0xe21ec3068a538a064ff0bdd69db0204306fc00a0",
+"name": "WIPcoin",
+"symbol": "WIP",
+"decimals": 18,
+"logoURI": "https://res.cloudinary.com/dygslmg93/image/upload/v1758780817/thewiplogo3_doqyny.png"
+}
 ]


### PR DESCRIPTION
Add WIPcoin to Uniswap token list

Base chainId 8453

Address: 0xe21ec3068a538a064ff0bdd69db0204306fc00a0
Block Explorer: https://basescan.org/token/0xe21ec3068a538a064ff0bdd69db0204306fc00a0
Token Image: https://res.cloudinary.com/dygslmg93/image/upload/v1758780817/thewiplogo3_doqyny.png

Whitepaper on IPFS: https://plum-hon-sparrow-417.mypinata.cloud/ipfs/bafkreic3lccgwu5y44edljd2bcu4zkwxpojkgi3beq4lw4slifnmiez76y


The WIPcoin WHITEPAPER


The WIP Meetup is the longest-running virtual meetup in the crypto space. It originally started on Cent, a Web3 platform that incentivized community engagement in 2020. Over the years, the WIP has called many different platforms home, specifically the Tokensmart and Meme Explorers community Discord servers. The WIP Meetup is best known for providing Web3 builders, creators, artists, and personalities with a platform to present their current products or projects to a group of highly knowledgeable crypto users who offer real-time opinions and valuable feedback that would otherwise be extremely costly to obtain in a beta or alpha cohort. Many notable brands in crypto have attended or presented at the WIP. Each week for six years and counting, WIP community members explore various metaverse platforms and experiment live in real time.

The community is also known for weekly giveaways in the form of donated Web3 products from presenters at the event, in addition to items created by WIP team members for attendees. This ultimately led to the creation of WIPcoin ($WIP), an ecosystem token that represents participation in the WIP Meetup event and associated community-related initiatives.