### PR TITLE
Add Nita Coin (NITA) to default tokenlist

### DIFF
--- a/nita.json
+++ b/nita.json
@@ -1,0 +1,10 @@
+{
+  "name": "Nita Coin",
+  "symbol": "NITA",
+  "address": "0x543c24e41005c52DD77E2052579a8D652B6c14d8",
+  "chainId": 1,
+  "decimals": 18,
+  "logoURI": "https://upload.wikimedia.org/wikipedia/commons/6/65/No-Image-Placeholder.svg",
+  "tags": ["utility-token"],
+  "extensions": {}
+}


### PR DESCRIPTION
ERC-20 token, verified contract, 18 decimals, open trading