### PR TITLE
add elizaOS

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/default-token-list",
-  "version": "16.3.0",
+  "version": "16.4.0",
   "description": "The Uniswap default token list",
   "main": "build/uniswap-default.tokenlist.json",
   "scripts": {

--- a/src/tokens/base.json
+++ b/src/tokens/base.json
@@ -390,5 +390,13 @@
     "symbol": "UNI",
     "decimals": 18,
     "logoURI": "https://ethereum-optimism.github.io/data/UNI/logo.png"
+  },
+  {
+    "chainId": 8453,
+    "address": "0xea17Df5Cf6D172224892B5477A16ACb111182478",
+    "name": "elizaOS",
+    "symbol": "ELIZAOS",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/38888/large/elizaos.png"
   }
 ]

--- a/src/tokens/bnb.json
+++ b/src/tokens/bnb.json
@@ -22,5 +22,13 @@
     "symbol": "KUJI",
     "decimals": 6,
     "logoURI": "https://assets.coingecko.com/coins/images/20685/standard/kuji-200x200.png"
+  },
+  {
+    "chainId": 56,
+    "address": "0xea17Df5Cf6D172224892B5477A16ACb111182478",
+    "name": "elizaOS",
+    "symbol": "ELIZAOS",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/38888/large/elizaos.png"
   }
 ]

--- a/src/tokens/mainnet.json
+++ b/src/tokens/mainnet.json
@@ -2736,5 +2736,13 @@
     "symbol": "AUDD",
     "decimals": 6,
     "logoURI": "https://coin-images.coingecko.com/coins/images/33263/large/AUDD-Logo-Blue_512.png?1701319895"
+  },
+  {
+    "chainId": 1,
+    "address": "0xea17Df5Cf6D172224892B5477A16ACb111182478",
+    "name": "elizaOS",
+    "symbol": "ELIZAOS",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/38888/large/elizaos.png"
   }
 ]

--- a/src/tokens/solana.json
+++ b/src/tokens/solana.json
@@ -336,6 +336,14 @@
     "logoURI": "https://coin-images.coingecko.com/coins/images/14962/large/6GxcPRo3_400x400.jpg?1696514622"
   },
   {
+    "name": "elizaOS",
+    "address": "DuMbhu7mvQvqQHGcnikDgb4XegXJRyhUBfdU22uELiZA",
+    "symbol": "ELIZAOS",
+    "decimals": 9,
+    "chainId": 501000101,
+    "logoURI": "https://assets.coingecko.com/coins/images/38888/large/elizaos.png"
+  },
+  {
     "name": "Eclipse",
     "address": "BqPqrrQuoQXFGGEAEMnPmDgZ6RWQCajWnY3V6Yp4DZWP",
     "symbol": "ES",


### PR DESCRIPTION
* add elizaOS to mainnet, base, and bnb

Token information:
- Name: elizaOS
- Symbol: ELIZAOS
- Decimals: 18
- Mainnet: 0xea17Df5Cf6D172224892B5477A16ACb111182478
- Base: 0xea17Df5Cf6D172224892B5477A16ACb111182478
- BNB: 0xea17Df5Cf6D172224892B5477A16ACb111182478

Source: https://coinmarketcap.com/currencies/elizaos/