### PR TITLE
Add EIC token registryAdd Energy Intelligence Coin (EIC) token

### DIFF
--- a/src/tokens/src/tokens/eic.json
+++ b/src/tokens/src/tokens/eic.json
@@ -1,0 +1,13 @@
+{
+  "name": "Energy Intelligence Coin",
+  "symbol": "EIC",
+  "chainId": 1,
+  "address": "0x867776d88DfD7061324FD97C8e03fb2DcC29a024",
+  "decimals": 18,
+  "logoURI": "ipfs://bafkreig6vy3sq6wvmzzi7trvli7nmitfqtvdqeukqh3eguyvtoxpehjkwy",
+  "tags": [
+    "defi",
+    "energy",
+    "ai"
+  ]
+}


### PR DESCRIPTION
This PR adds EIC (Energy Intelligence Coin) to the Uniswap default token list.
- Symbol: EIC
- Decimals: 18
- Chain: Ethereum Mainnet
- Logo: IPFS
- Tags: defi, energy, ai