### PR TITLE
fix: resolve zizmor GitHub Actions security findings

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -20,6 +20,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
 
       - name: Setup Node
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,13 +1,17 @@
 name: Tests
 on: [push, pull_request]
+permissions: {}
+
 jobs:
   test:
     runs-on: ubuntu-latest
     name: Unit Tests
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+        with:
+          persist-credentials: false
       - name: Setup node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1
         with:
           node-version: 16
       - run: yarn install --frozen-lockfile


### PR DESCRIPTION
## Summary
- Ran zizmor static analysis on GitHub Actions workflows
- Fixed credential persistence issues (persist-credentials: false)
- Added minimal permissions blocks where missing
- Pinned unpinned action references to commit SHAs
- Fixed template injection vulnerabilities where auto-fixable

Generated by zizmor v1.22.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)