### PR TITLE
Add wQBC: Wrapped Qubitcoin

### DIFF
--- a/src/tokens/mainnet.json
+++ b/src/tokens/mainnet.json
@@ -3071,5 +3071,13 @@
     "symbol": "EDGEX",
     "decimals": 18,
     "logoURI": "https://assets.coingecko.com/markets/images/11726/large/Logo_White_-_Black_BG.png?1727920571"
+  },
+  {
+    "name": "Wrapped Qubitcoin",
+    "address": "0xB7c8783dDfb7f72b2C27AFBDFFD2B0206046Fa67",
+    "symbol": "wQBC",
+    "decimals": 8,
+    "chainId": 1,
+    "logoURI": "https://qbc.network/qbc-logo.png"
   }
 ]


### PR DESCRIPTION
## Token Information

- **Token Name:** Wrapped Qubitcoin
- **Token Symbol:** wQBC
- **Token Address:** `0xB7c8783dDfb7f72b2C27AFBDFFD2B0206046Fa67`
- **Chain ID:** 1 (Ethereum Mainnet)
- **Decimals:** 8
- **Logo URI:** https://qbc.network/qbc-logo.png

## About Qubitcoin (QBC)

Qubitcoin is a quantum-resistant Layer 1 blockchain using CRYSTALS-Dilithium5 cryptography and Proof-of-SUSY-Alignment consensus. wQBC is the wrapped ERC-20 representation of the native QBC token on Ethereum.

- **Homepage:** https://qbc.network
- **Block Explorer:** https://explorer.qbc.network
- **Documentation:** https://docs.qbc.network

## Checklist

- [x] Token contract is verified on Etherscan
- [x] Token has active liquidity on Uniswap
- [x] Logo hosted at a stable URL