### PR TITLE
Add MMC Coin (MemeCEX) to Ethereum mainnet token list

### DIFF
--- a/src/tokens/mainnet.json
+++ b/src/tokens/mainnet.json
@@ -1,220 +1,19 @@
 [
   {
-    "name": "Wrapped Ether",
-    "address": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
-    "symbol": "WETH",
+    "chainId": 1,
+    "address": "0x111111111117dC0aa78b770fA6A738034120C302",
+    "name": "1inch",
+    "symbol": "1INCH",
     "decimals": 18,
-    "chainId": 1,
-    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
-    "extensions": {
-      "bridgeInfo": {
-        "10": {
-          "tokenAddress": "0x4200000000000000000000000000000000000006"
-        },
-        "137": {
-          "tokenAddress": "0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619"
-        },
-        "42161": {
-          "tokenAddress": "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1"
-        },
-        "42220": {
-          "tokenAddress": "0x2DEf4285787d58a2f811AF24755A8150622f4361"
-        }
-      }
-    }
+    "logoURI": "https://assets.coingecko.com/coins/images/13469/thumb/1inch-token.png?1608803028"
   },
   {
-    "name": "Dai Stablecoin",
-    "address": "0x6B175474E89094C44Da98b954EedeAC495271d0F",
-    "symbol": "DAI",
+    "chainId": 1,
+    "address": "0x3E5A19c91266aD8cE2477B91585d1856B84062dF",
+    "name": "Ancient8",
+    "symbol": "A8",
     "decimals": 18,
-    "chainId": 1,
-    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png"
-  },
-  {
-    "name": "0x Protocol Token",
-    "address": "0xE41d2489571d322189246DaFA5ebDe1F4699F498",
-    "symbol": "ZRX",
-    "decimals": 18,
-    "chainId": 1,
-    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xE41d2489571d322189246DaFA5ebDe1F4699F498/logo.png"
-  },
-  {
-    "name": "Curve DAO Token",
-    "address": "0xD533a949740bb3306d119CC777fa900bA034cd52",
-    "symbol": "CRV",
-    "decimals": 18,
-    "chainId": 1,
-    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xD533a949740bb3306d119CC777fa900bA034cd52/logo.png"
-  },
-  {
-    "name": "Uniswap",
-    "address": "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984",
-    "symbol": "UNI",
-    "decimals": 18,
-    "chainId": 1,
-    "logoURI": "ipfs://QmXttGpZrECX5qCyXbBQiqgQNytVGeZW5Anewvh2jc4psg"
-  },
-  {
-    "name": "Tether USD",
-    "address": "0xdAC17F958D2ee523a2206206994597C13D831ec7",
-    "symbol": "USDT",
-    "decimals": 6,
-    "chainId": 1,
-    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdAC17F958D2ee523a2206206994597C13D831ec7/logo.png",
-    "extensions": {
-      "bridgeInfo": {
-        "42220": {
-          "tokenAddress": "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e"
-        }
-      }
-    }
-  },
-  {
-    "name": "USDCoin",
-    "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
-    "symbol": "USDC",
-    "decimals": 6,
-    "chainId": 1,
-    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png",
-    "extensions": {
-      "bridgeInfo": {
-        "42161": {
-          "tokenAddress": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831"
-        },
-        "42220": {
-          "tokenAddress": "0xcebA9300f2b948710d2653dD7B07f33A8B32118C"
-        }
-      }
-    }
-  },
-  {
-    "name": "Orchid",
-    "address": "0x4575f41308EC1483f3d399aa9a2826d74Da13Deb",
-    "symbol": "OXT",
-    "decimals": 18,
-    "chainId": 1,
-    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4575f41308EC1483f3d399aa9a2826d74Da13Deb/logo.png"
-  },
-  {
-    "name": "Maker",
-    "address": "0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2",
-    "symbol": "MKR",
-    "decimals": 18,
-    "chainId": 1,
-    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2/logo.png"
-  },
-  {
-    "name": "ChainLink Token",
-    "address": "0x514910771AF9Ca656af840dff83E8264EcF986CA",
-    "symbol": "LINK",
-    "decimals": 18,
-    "chainId": 1,
-    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x514910771AF9Ca656af840dff83E8264EcF986CA/logo.png"
-  },
-  {
-    "name": "Reputation Augur v1",
-    "address": "0x1985365e9f78359a9B6AD760e32412f4a445E862",
-    "symbol": "REP",
-    "decimals": 18,
-    "chainId": 1,
-    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1985365e9f78359a9B6AD760e32412f4a445E862/logo.png"
-  },
-  {
-    "name": "Reputation Augur v2",
-    "address": "0x221657776846890989a759BA2973e427DfF5C9bB",
-    "symbol": "REPv2",
-    "decimals": 18,
-    "chainId": 1,
-    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x221657776846890989a759BA2973e427DfF5C9bB/logo.png"
-  },
-  {
-    "name": "Kyber Network Crystal",
-    "address": "0xdd974D5C2e2928deA5F71b9825b8b646686BD200",
-    "symbol": "KNC",
-    "decimals": 18,
-    "chainId": 1,
-    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdd974D5C2e2928deA5F71b9825b8b646686BD200/logo.png"
-  },
-  {
-    "name": "Compound",
-    "address": "0xc00e94Cb662C3520282E6f5717214004A7f26888",
-    "symbol": "COMP",
-    "decimals": 18,
-    "chainId": 1,
-    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xc00e94Cb662C3520282E6f5717214004A7f26888/logo.png"
-  },
-  {
-    "chainId": 1,
-    "address": "0xBA11D00c5f74255f56a5E366F4F77f5A186d7f55",
-    "name": "Band Protocol",
-    "symbol": "BAND",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/9545/thumb/band-protocol.png?1568730326"
-  },
-  {
-    "name": "Numeraire",
-    "address": "0x1776e1F26f98b1A5dF9cD347953a26dd3Cb46671",
-    "symbol": "NMR",
-    "decimals": 18,
-    "chainId": 1,
-    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1776e1F26f98b1A5dF9cD347953a26dd3Cb46671/logo.png"
-  },
-  {
-    "name": "UMA Voting Token v1",
-    "address": "0x04Fa0d235C4abf4BcF4787aF4CF447DE572eF828",
-    "symbol": "UMA",
-    "decimals": 18,
-    "chainId": 1,
-    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x04Fa0d235C4abf4BcF4787aF4CF447DE572eF828/logo.png"
-  },
-  {
-    "name": "LoopringCoin V2",
-    "address": "0xBBbbCA6A901c926F240b89EacB641d8Aec7AEafD",
-    "symbol": "LRC",
-    "decimals": 18,
-    "chainId": 1,
-    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xBBbbCA6A901c926F240b89EacB641d8Aec7AEafD/logo.png"
-  },
-  {
-    "chainId": 1,
-    "address": "0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e",
-    "name": "yearn finance",
-    "symbol": "YFI",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/11849/thumb/yfi-192x192.png?1598325330"
-  },
-  {
-    "name": "Republic Token",
-    "address": "0x408e41876cCCDC0F92210600ef50372656052a38",
-    "symbol": "REN",
-    "decimals": 18,
-    "chainId": 1,
-    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x408e41876cCCDC0F92210600ef50372656052a38/logo.png"
-  },
-  {
-    "name": "Wrapped BTC",
-    "address": "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599",
-    "symbol": "WBTC",
-    "decimals": 8,
-    "chainId": 1,
-    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599/logo.png"
-  },
-  {
-    "name": "Balancer",
-    "address": "0xba100000625a3754423978a60c9317c58a424e3D",
-    "symbol": "BAL",
-    "decimals": 18,
-    "chainId": 1,
-    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xba100000625a3754423978a60c9317c58a424e3D/logo.png"
-  },
-  {
-    "chainId": 1,
-    "address": "0x4fE83213D56308330EC302a8BD641f1d0113A4Cc",
-    "name": "NuCypher",
-    "symbol": "NU",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/3318/thumb/photo1198982838879365035.jpg?1547037916"
+    "logoURI": "https://assets.coingecko.com/coins/images/39170/standard/A8_Token-04_200x200.png?1720798300"
   },
   {
     "chainId": 1,
@@ -233,1034 +32,11 @@
   },
   {
     "chainId": 1,
-    "address": "0xc944E90C64B2c07662A292be6244BDf05Cda44a7",
-    "name": "The Graph",
-    "symbol": "GRT",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/13397/thumb/Graph_Token.png?1608145566"
-  },
-  {
-    "name": "Bancor Network Token",
-    "address": "0x1F573D6Fb3F13d689FF844B4cE37794d79a7FF1C",
-    "symbol": "BNT",
-    "decimals": 18,
-    "chainId": 1,
-    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1F573D6Fb3F13d689FF844B4cE37794d79a7FF1C/logo.png"
-  },
-  {
-    "name": "Synthetix Network Token",
-    "address": "0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F",
-    "symbol": "SNX",
-    "decimals": 18,
-    "chainId": 1,
-    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F/logo.png"
-  },
-  {
-    "chainId": 1,
-    "address": "0x0F5D2fB29fb7d3CFeE444a200298f468908cC942",
-    "name": "Decentraland",
-    "symbol": "MANA",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/878/thumb/decentraland-mana.png?1550108745"
-  },
-  {
-    "name": "Loom Network",
-    "address": "0xA4e8C3Ec456107eA67d3075bF9e3DF3A75823DB0",
-    "symbol": "LOOM",
-    "decimals": 18,
-    "chainId": 1,
-    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA4e8C3Ec456107eA67d3075bF9e3DF3A75823DB0/logo.png"
-  },
-  {
-    "chainId": 1,
-    "address": "0x41e5560054824eA6B0732E656E3Ad64E20e94E45",
-    "name": "Civic",
-    "symbol": "CVC",
-    "decimals": 8,
-    "logoURI": "https://assets.coingecko.com/coins/images/788/thumb/civic.png?1547034556"
-  },
-  {
-    "chainId": 1,
-    "address": "0x0AbdAce70D3790235af448C88547603b945604ea",
-    "name": "district0x",
-    "symbol": "DNT",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/849/thumb/district0x.png?1547223762"
-  },
-  {
-    "name": "Storj Token",
-    "address": "0xB64ef51C888972c908CFacf59B47C1AfBC0Ab8aC",
-    "symbol": "STORJ",
-    "decimals": 8,
-    "chainId": 1,
-    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xB64ef51C888972c908CFacf59B47C1AfBC0Ab8aC/logo.png"
-  },
-  {
-    "chainId": 1,
-    "address": "0xfF20817765cB7f73d4bde2e66e067E58D11095C2",
-    "name": "Amp",
-    "symbol": "AMP",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/12409/thumb/amp-200x200.png?1599625397"
-  },
-  {
-    "name": "Gnosis Token",
-    "address": "0x6810e776880C02933D47DB1b9fc05908e5386b96",
-    "symbol": "GNO",
-    "decimals": 18,
-    "chainId": 1,
-    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6810e776880C02933D47DB1b9fc05908e5386b96/logo.png"
-  },
-  {
-    "name": "Aragon",
-    "address": "0xa117000000f279D81A1D3cc75430fAA017FA5A2e",
-    "symbol": "ANT",
-    "decimals": 18,
-    "chainId": 1,
-    "logoURI": "https://assets.coingecko.com/coins/images/681/thumb/JelZ58cv_400x400.png?1601449653"
-  },
-  {
-    "chainId": 1,
-    "address": "0x85Eee30c52B0b379b046Fb0F85F4f3Dc3009aFEC",
-    "name": "Keep Network",
-    "symbol": "KEEP",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/3373/thumb/IuNzUb5b_400x400.jpg?1589526336"
-  },
-  {
-    "chainId": 1,
-    "address": "0x18084fbA666a33d37592fA2633fD49a74DD93a88",
-    "name": "tBTC",
-    "symbol": "tBTC",
-    "decimals": 18,
-    "logoURI": "https://raw.githubusercontent.com/uniswap/assets/master/blockchains/ethereum/assets/0x18084fbA666a33d37592fA2633fD49a74DD93a88/logo.png"
-  },
-  {
-    "chainId": 1,
-    "address": "0xec67005c4E498Ec7f55E092bd1d35cbC47C91892",
-    "name": "Melon",
-    "symbol": "MLN",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/605/thumb/melon.png?1547034295"
-  },
-  {
-    "chainId": 1,
-    "address": "0xC18360217D8F7Ab5e7c516566761Ea12Ce7F9D72",
-    "name": "Ethereum Name Service",
-    "symbol": "ENS",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/19785/thumb/acatxTm8_400x400.jpg?1635850140"
-  },
-  {
-    "name": "Synth sUSD",
-    "address": "0x57Ab1ec28D129707052df4dF418D58a2D46d5f51",
-    "symbol": "sUSD",
-    "decimals": 18,
-    "chainId": 1,
-    "logoURI": "https://assets.coingecko.com/coins/images/5013/thumb/sUSD.png?1616150765"
-  },
-  {
-    "chainId": 1,
-    "address": "0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0",
-    "name": "Polygon",
-    "symbol": "MATIC",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/4713/thumb/matic-token-icon.png?1624446912",
-    "extensions": {
-      "bridgeInfo": {
-        "137": {
-          "tokenAddress": "0x0000000000000000000000000000000000001010"
-        }
-      }
-    }
-  },
-  {
-    "chainId": 1,
-    "address": "0x4d224452801ACEd8B2F0aebE155379bb5D594381",
-    "name": "ApeCoin",
-    "symbol": "APE",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/24383/small/apecoin.jpg?1647476455"
-  },
-  {
-    "chainId": 1,
-    "address": "0x111111111117dC0aa78b770fA6A738034120C302",
-    "name": "1inch",
-    "symbol": "1INCH",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/13469/thumb/1inch-token.png?1608803028"
-  },
-  {
-    "chainId": 1,
-    "address": "0x91Af0fBB28ABA7E31403Cb457106Ce79397FD4E6",
-    "name": "Aergo",
-    "symbol": "AERGO",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/4490/thumb/aergo.png?1647696770"
-  },
-  {
-    "chainId": 1,
-    "address": "0x626E8036dEB333b408Be468F951bdB42433cBF18",
-    "name": "AIOZ Network",
-    "symbol": "AIOZ",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/14631/thumb/aioz_logo.png?1617413126"
-  },
-  {
-    "chainId": 1,
-    "address": "0xdBdb4d16EdA451D0503b854CF79D55697F90c8DF",
-    "name": "Alchemix",
-    "symbol": "ALCX",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/14113/thumb/Alchemix.png?1614409874"
-  },
-  {
-    "chainId": 1,
-    "address": "0x845576c64f9754CF09d87e45B720E82F3EeF522C",
-    "name": "Artverse Token",
-    "symbol": "AVT",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/19727/thumb/ewnektoB_400x400.png?1635767094"
-  },
-  {
-    "chainId": 1,
-    "address": "0x32353A6C91143bfd6C7d363B546e62a9A2489A20",
-    "name": "Adventure Gold",
-    "symbol": "AGLD",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/18125/thumb/lpgblc4h_400x400.jpg?1630570955"
-  },
-  {
-    "chainId": 1,
-    "address": "0x0391D2021f89DC339F60Fff84546EA23E337750f",
-    "name": "BarnBridge",
-    "symbol": "BOND",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/12811/thumb/barnbridge.jpg?1602728853"
-  },
-  {
-    "chainId": 1,
-    "address": "0x77FbA179C79De5B7653F68b5039Af940AdA60ce0",
-    "name": "Ampleforth Governance Token",
-    "symbol": "FORTH",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/14917/thumb/photo_2021-04-22_00.00.03.jpeg?1619020835"
-  },
-  {
-    "chainId": 1,
-    "address": "0x8290333ceF9e6D528dD5618Fb97a76f268f3EDD4",
-    "name": "Ankr",
-    "symbol": "ANKR",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/4324/thumb/U85xTl2.png?1608111978"
-  },
-  {
-    "chainId": 1,
-    "address": "0x0b38210ea11411557c13457D4dA7dC6ea731B88a",
-    "name": "API3",
-    "symbol": "API3",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/13256/thumb/api3.jpg?1606751424"
-  },
-  {
-    "chainId": 1,
-    "address": "0xBA50933C268F567BDC86E1aC131BE072C6B0b71a",
-    "name": "ARPA Chain",
-    "symbol": "ARPA",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/8506/thumb/9u0a23XY_400x400.jpg?1559027357"
-  },
-  {
-    "chainId": 1,
-    "address": "0x2565ae0385659badCada1031DB704442E1b69982",
-    "name": "Assemble Protocol",
-    "symbol": "ASM",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/11605/thumb/gpvrlkSq_400x400_%281%29.jpg?1591775789"
-  },
-  {
-    "chainId": 1,
-    "address": "0x80C62FE4487E1351b47Ba49809EBD60ED085bf52",
-    "name": "Clover Finance",
-    "symbol": "CLV",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/15278/thumb/clover.png?1645084454"
-  },
-  {
-    "chainId": 1,
-    "address": "0x321C2fE4446C7c963dc41Dd58879AF648838f98D",
-    "name": "Cryptex Finance",
-    "symbol": "CTX",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/14932/thumb/glossy_icon_-_C200px.png?1619073171"
-  },
-  {
-    "chainId": 1,
-    "address": "0xBB0E17EF65F82Ab018d8EDd776e8DD940327B28b",
-    "name": "Axie Infinity",
-    "symbol": "AXS",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/13029/thumb/axie_infinity_logo.png?1604471082"
-  },
-  {
-    "chainId": 1,
-    "address": "0x3472A5A71965499acd81997a54BBA8D852C6E53d",
-    "name": "Badger DAO",
-    "symbol": "BADGER",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/13287/thumb/badger_dao_logo.jpg?1607054976"
-  },
-  {
-    "chainId": 1,
-    "address": "0xA0b73E1Ff0B80914AB6fe0444E65848C4C34450b",
-    "name": "Cronos",
-    "symbol": "CRO",
-    "decimals": 8,
-    "logoURI": "https://assets.coingecko.com/coins/images/7310/thumb/oCw2s3GI_400x400.jpeg?1645172042"
-  },
-  {
-    "chainId": 1,
-    "address": "0x0D8775F648430679A709E98d2b0Cb6250d2887EF",
-    "name": "Basic Attention Token",
-    "symbol": "BAT",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/677/thumb/basic-attention-token.png?1547034427"
-  },
-  {
-    "chainId": 1,
-    "address": "0xF17e65822b568B3903685a7c9F496CF7656Cc6C2",
-    "name": "Biconomy",
-    "symbol": "BICO",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/21061/thumb/biconomy_logo.jpg?1638269749"
-  },
-  {
-    "chainId": 1,
-    "address": "0xDe30da39c46104798bB5aA3fe8B9e0e1F348163F",
-    "name": "Gitcoin",
-    "symbol": "GTC",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/15810/thumb/gitcoin.png?1621992929"
-  },
-  {
-    "chainId": 1,
-    "address": "0xF57e7e7C23978C3cAEC3C3548E3D615c346e79fF",
-    "name": "Immutable X",
-    "symbol": "IMX",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/17233/thumb/imx.png?1636691817"
-  },
-  {
-    "chainId": 1,
-    "address": "0x5732046A883704404F284Ce41FfADd5b007FD668",
-    "name": "Bluzelle",
-    "symbol": "BLZ",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/2848/thumb/ColorIcon_3x.png?1622516510"
-  },
-  {
-    "chainId": 1,
-    "address": "0x69af81e73A73B40adF4f3d4223Cd9b1ECE623074",
-    "name": "Mask Network",
-    "symbol": "MASK",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/14051/thumb/Mask_Network.jpg?1614050316"
-  },
-  {
-    "chainId": 1,
-    "address": "0xA9B1Eb5908CfC3cdf91F9B8B3a74108598009096",
-    "name": "Bounce",
-    "symbol": "AUCTION",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/13860/thumb/1_KtgpRIJzuwfHe0Rl0avP_g.jpeg?1612412025"
-  },
-  {
-    "chainId": 1,
-    "address": "0x799ebfABE77a6E34311eeEe9825190B9ECe32824",
-    "name": "Braintrust",
-    "symbol": "BTRST",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/18100/thumb/braintrust.PNG?1630475394"
-  },
-  {
-    "chainId": 1,
-    "address": "0x491604c0FDF08347Dd1fa4Ee062a822A5DD06B5D",
-    "name": "Cartesi",
-    "symbol": "CTSI",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/11038/thumb/cartesi.png?1592288021"
-  },
-  {
-    "chainId": 1,
-    "address": "0xD8912C10681D8B21Fd3742244f44658dBA12264E",
-    "name": "Pluton",
-    "symbol": "PLU",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/1241/thumb/pluton.png?1548331624"
-  },
-  {
-    "chainId": 1,
-    "address": "0x3506424F91fD33084466F402d5D97f05F8e3b4AF",
-    "name": "Chiliz",
-    "symbol": "CHZ",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/8834/thumb/Chiliz.png?1561970540"
-  },
-  {
-    "chainId": 1,
-    "address": "0x9E46A38F5DaaBe8683E10793b06749EEF7D733d1",
-    "name": "PolySwarm",
-    "symbol": "NCT",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/2843/thumb/ImcYCVfX_400x400.jpg?1628519767"
-  },
-  {
-    "chainId": 1,
-    "address": "0x03ab458634910AaD20eF5f1C8ee96F1D6ac54919",
-    "name": "Rai Reflex Index",
-    "symbol": "RAI",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/14004/thumb/RAI-logo-coin.png?1613592334"
-  },
-  {
-    "chainId": 1,
-    "address": "0xDDB3422497E61e13543BeA06989C0789117555c5",
-    "name": "COTI",
-    "symbol": "COTI",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/2962/thumb/Coti.png?1559653863"
-  },
-  {
-    "chainId": 1,
-    "address": "0xD31a59c85aE9D8edEFeC411D448f90841571b89c",
-    "name": "SOL Wormhole ",
-    "symbol": "SOL",
-    "decimals": 9,
-    "logoURI": "https://assets.coingecko.com/coins/images/22876/thumb/SOL_wh_small.png?1644224316"
-  },
-  {
-    "chainId": 1,
-    "address": "0x08389495D7456E1951ddF7c3a1314A4bfb646d8B",
-    "name": "Crypterium",
-    "symbol": "CRPT",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/1901/thumb/crypt.png?1547036205"
-  },
-  {
-    "chainId": 1,
-    "address": "0xe53EC727dbDEB9E2d5456c3be40cFF031AB40A55",
-    "name": "SuperFarm",
-    "symbol": "SUPER",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/14040/thumb/6YPdWn6.png?1613975899"
-  },
-  {
-    "chainId": 1,
-    "address": "0x0f2D719407FdBeFF09D87557AbB7232601FD9F29",
-    "name": "Synapse",
-    "symbol": "SYN",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/18024/thumb/syn.png?1635002049"
-  },
-  {
-    "chainId": 1,
-    "address": "0x4C19596f5aAfF459fA38B0f7eD92F11AE6543784",
-    "name": "TrueFi",
-    "symbol": "TRU",
-    "decimals": 8,
-    "logoURI": "https://assets.coingecko.com/coins/images/13180/thumb/truefi_glyph_color.png?1617610941"
-  },
-  {
-    "chainId": 1,
-    "address": "0x3A880652F47bFaa771908C07Dd8673A787dAEd3A",
-    "name": "DerivaDAO",
-    "symbol": "DDX",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/13453/thumb/ddx_logo.png?1608741641"
-  },
-  {
-    "chainId": 1,
-    "address": "0xa1d0E215a23d7030842FC67cE582a6aFa3CCaB83",
-    "name": "DFI money",
-    "symbol": "YFII",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/11902/thumb/YFII-logo.78631676.png?1598677348"
-  },
-  {
-    "chainId": 1,
-    "address": "0x84cA8bc7997272c7CfB4D0Cd3D55cd942B3c9419",
-    "name": "DIA",
-    "symbol": "DIA",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/11955/thumb/image.png?1646041751"
-  },
-  {
-    "chainId": 1,
-    "address": "0xA4EED63db85311E22dF4473f87CcfC3DaDCFA3E3",
-    "name": "Rubic",
-    "symbol": "RBC",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/12629/thumb/200x200.png?1607952509"
-  },
-  {
-    "chainId": 1,
-    "address": "0xF629cBd94d3791C9250152BD8dfBDF380E2a3B9c",
-    "name": "Enjin Coin",
-    "symbol": "ENJ",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/1102/thumb/enjin-coin-logo.png?1547035078"
-  },
-  {
-    "chainId": 1,
-    "address": "0xba5BDe662c17e2aDFF1075610382B9B691296350",
-    "name": "SuperRare",
-    "symbol": "RARE",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/17753/thumb/RARE.jpg?1629220534"
-  },
-  {
-    "chainId": 1,
-    "address": "0x2e9d63788249371f1DFC918a52f8d799F4a38C94",
-    "name": "Tokemak",
-    "symbol": "TOKE",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/17495/thumb/tokemak-avatar-200px-black.png?1628131614"
-  },
-  {
-    "chainId": 1,
-    "address": "0xBBc2AE13b23d715c30720F079fcd9B4a74093505",
-    "name": "Ethernity Chain",
-    "symbol": "ERN",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/14238/thumb/LOGO_HIGH_QUALITY.png?1647831402"
-  },
-  {
-    "chainId": 1,
-    "address": "0xaea46A60368A7bD060eec7DF8CBa43b7EF41Ad85",
-    "name": "Fetch ai",
-    "symbol": "FET",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/5681/thumb/Fetch.jpg?1572098136"
-  },
-  {
-    "chainId": 1,
-    "address": "0x8c15Ef5b4B21951d50E53E4fbdA8298FFAD25057",
-    "name": "Function X",
-    "symbol": "FX",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/8186/thumb/47271330_590071468072434_707260356350705664_n.jpg?1556096683"
-  },
-  {
-    "chainId": 1,
-    "address": "0xccC8cb5229B0ac8069C51fd58367Fd1e622aFD97",
-    "name": "Gods Unchained",
-    "symbol": "GODS",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/17139/thumb/10631.png?1635718182"
-  },
-  {
-    "chainId": 1,
-    "address": "0xdab396cCF3d84Cf2D07C4454e10C8A6F5b008D2b",
-    "name": "Goldfinch",
-    "symbol": "GFI",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/19081/thumb/GOLDFINCH.png?1634369662"
-  },
-  {
-    "chainId": 1,
-    "address": "0x7DD9c5Cba05E151C895FDe1CF355C9A1D5DA6429",
-    "name": "Golem",
-    "symbol": "GLM",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/542/thumb/Golem_Submark_Positive_RGB.png?1606392013"
-  },
-  {
-    "chainId": 1,
-    "address": "0xC08512927D12348F6620a698105e1BAac6EcD911",
-    "name": "GYEN",
-    "symbol": "GYEN",
-    "decimals": 6,
-    "logoURI": "https://assets.coingecko.com/coins/images/14191/thumb/icon_gyen_200_200.png?1614843343"
-  },
-  {
-    "chainId": 1,
-    "address": "0xa0246c9032bC3A600820415aE600c6388619A14D",
-    "name": "Harvest Finance",
-    "symbol": "FARM",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/12304/thumb/Harvest.png?1613016180"
-  },
-  {
-    "chainId": 1,
-    "address": "0x71Ab77b7dbB4fa7e017BC15090b2163221420282",
-    "name": "Highstreet",
-    "symbol": "HIGH",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/18973/thumb/logosq200200Coingecko.png?1634090470"
-  },
-  {
-    "chainId": 1,
-    "address": "0xB705268213D593B8FD88d3FDEFF93AFF5CbDcfAE",
-    "name": "IDEX",
-    "symbol": "IDEX",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/2565/thumb/logomark-purple-286x286.png?1638362736"
-  },
-  {
-    "chainId": 1,
-    "address": "0x607F4C5BB672230e8672085532f7e901544a7375",
-    "name": "iExec RLC",
-    "symbol": "RLC",
-    "decimals": 9,
-    "logoURI": "https://assets.coingecko.com/coins/images/646/thumb/pL1VuXm.png?1604543202"
-  },
-  {
-    "chainId": 1,
-    "address": "0x41D5D79431A913C4aE7d69a668ecdfE5fF9DFB68",
-    "name": "Inverse Finance",
-    "symbol": "INV",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/14205/thumb/inverse_finance.jpg?1614921871"
-  },
-  {
-    "chainId": 1,
-    "address": "0x7420B4b9a0110cdC71fB720908340C03F9Bc03EC",
-    "name": "JasmyCoin",
-    "symbol": "JASMY",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/13876/thumb/JASMY200x200.jpg?1612473259"
-  },
-  {
-    "chainId": 1,
-    "address": "0x464eBE77c293E473B48cFe96dDCf88fcF7bFDAC0",
-    "name": "KRYLL",
-    "symbol": "KRL",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/2807/thumb/krl.png?1547036979"
-  },
-  {
-    "chainId": 1,
-    "address": "0x037A54AaB062628C9Bbae1FDB1583c195585fe41",
-    "name": "LCX",
-    "symbol": "LCX",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/9985/thumb/zRPSu_0o_400x400.jpg?1574327008"
-  },
-  {
-    "chainId": 1,
-    "address": "0x6DEA81C8171D0bA574754EF6F8b412F2Ed88c54D",
-    "name": "Liquity",
-    "symbol": "LQTY",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/14665/thumb/200-lqty-icon.png?1617631180"
-  },
-  {
-    "chainId": 1,
-    "address": "0x58b6A8A3302369DAEc383334672404Ee733aB239",
-    "name": "Livepeer",
-    "symbol": "LPT",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/7137/thumb/logo-circle-green.png?1619593365"
-  },
-  {
-    "chainId": 1,
-    "address": "0x33349B282065b0284d756F0577FB39c158F935e6",
-    "name": "Maple",
-    "symbol": "MPL",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/14097/thumb/photo_2021-05-03_14.20.41.jpeg?1620022863"
-  },
-  {
-    "chainId": 1,
-    "address": "0x814e0908b12A99FeCf5BC101bB5d0b8B5cDf7d26",
-    "name": "Measurable Data Token",
-    "symbol": "MDT",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/2441/thumb/mdt_logo.png?1569813574"
-  },
-  {
-    "chainId": 1,
-    "address": "0x09a3EcAFa817268f77BE1283176B946C4ff2E608",
-    "name": "Mirror Protocol",
-    "symbol": "MIR",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/13295/thumb/mirror_logo_transparent.png?1611554658"
-  },
-  {
-    "chainId": 1,
-    "address": "0xfC98e825A2264D890F9a1e68ed50E1526abCcacD",
-    "name": "Moss Carbon Credit",
-    "symbol": "MCO2",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/14414/thumb/ENtxnThA_400x400.jpg?1615948522"
-  },
-  {
-    "chainId": 1,
-    "address": "0xe2f2a5C287993345a840Db3B0845fbC70f5935a5",
-    "name": "mStable USD",
-    "symbol": "MUSD",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/11576/thumb/mStable_USD.png?1595591803"
-  },
-  {
-    "chainId": 1,
-    "address": "0xd26114cd6EE289AccF82350c8d8487fedB8A0C07",
-    "name": "OMG Network",
-    "symbol": "OMG",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/776/thumb/OMG_Network.jpg?1591167168"
-  },
-  {
-    "chainId": 1,
-    "address": "0x8207c1FfC5B6804F6024322CcF34F29c3541Ae26",
-    "name": "Origin Protocol",
-    "symbol": "OGN",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/3296/thumb/op.jpg?1547037878"
-  },
-  {
-    "chainId": 1,
-    "address": "0xaA7a9CA87d3694B5755f213B5D04094b8d0F0A6F",
-    "name": "OriginTrail",
-    "symbol": "TRAC",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/1877/thumb/TRAC.jpg?1635134367"
-  },
-  {
-    "chainId": 1,
-    "address": "0x0258F474786DdFd37ABCE6df6BBb1Dd5dfC4434a",
-    "name": "Orion Protocol",
-    "symbol": "ORN",
-    "decimals": 8,
-    "logoURI": "https://assets.coingecko.com/coins/images/11841/thumb/orion_logo.png?1594943318"
-  },
-  {
-    "chainId": 1,
-    "address": "0x70D2b7C19352bB76e4409858FF5746e500f2B67c",
-    "name": "Pawtocol",
-    "symbol": "UPI",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/12186/thumb/pawtocol.jpg?1597962008"
-  },
-  {
-    "chainId": 1,
-    "address": "0xbC396689893D065F41bc2C6EcbeE5e0085233447",
-    "name": "Perpetual Protocol",
-    "symbol": "PERP",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/12381/thumb/60d18e06844a844ad75901a9_mark_only_03.png?1628674771"
-  },
-  {
-    "chainId": 1,
-    "address": "0x6fB3e0A217407EFFf7Ca062D46c26E5d60a14d69",
-    "name": "IoTeX",
-    "symbol": "IOTX",
-    "decimals": 18,
-    "logoURI": "https://s2.coinmarketcap.com/static/img/coins/64x64/2777.png"
-  },
-  {
-    "chainId": 1,
-    "address": "0x83e6f1E41cdd28eAcEB20Cb649155049Fac3D5Aa",
-    "name": "Polkastarter",
-    "symbol": "POLS",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/12648/thumb/polkastarter.png?1609813702"
-  },
-  {
-    "chainId": 1,
-    "address": "0x9992eC3cF6A55b00978cdDF2b27BC6882d88D1eC",
-    "name": "Polymath",
-    "symbol": "POLY",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/2784/thumb/inKkF01.png?1605007034"
-  },
-  {
-    "chainId": 1,
-    "address": "0x226bb599a12C826476e3A771454697EA52E9E220",
-    "name": "Propy",
-    "symbol": "PRO",
-    "decimals": 8,
-    "logoURI": "https://assets.coingecko.com/coins/images/869/thumb/propy.png?1548332100"
-  },
-  {
-    "chainId": 1,
-    "address": "0x4a220E6096B25EADb88358cb44068A3248254675",
-    "name": "Quant",
-    "symbol": "QNT",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/3370/thumb/5ZOu7brX_400x400.jpg?1612437252"
-  },
-  {
-    "chainId": 1,
-    "address": "0x99ea4dB9EE77ACD40B119BD1dC4E33e1C070b80d",
-    "name": "Quantstamp",
-    "symbol": "QSP",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/1219/thumb/0_E0kZjb4dG4hUnoDD_.png?1604815917"
-  },
-  {
-    "chainId": 1,
-    "address": "0x6c28AeF8977c9B773996d0e8376d2EE379446F2f",
-    "name": "Quickswap",
-    "symbol": "QUICK",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/13970/thumb/1_pOU6pBMEmiL-ZJVb0CYRjQ.png?1613386659"
-  },
-  {
-    "chainId": 1,
-    "address": "0x31c8EAcBFFdD875c74b94b077895Bd78CF1E64A3",
-    "name": "Radicle",
-    "symbol": "RAD",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/14013/thumb/radicle.png?1614402918"
-  },
-  {
-    "chainId": 1,
-    "address": "0x5Cf04716BA20127F1E2297AdDCf4B5035000c9eb",
-    "name": "NKN",
-    "symbol": "NKN",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/3375/thumb/nkn.png?1548329212"
-  },
-  {
-    "chainId": 1,
-    "address": "0xf1f955016EcbCd7321c7266BccFB96c68ea5E49b",
-    "name": "Rally",
-    "symbol": "RLY",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/12843/thumb/image.png?1611212077"
-  },
-  {
-    "chainId": 1,
-    "address": "0xD291E7a03283640FDc51b121aC401383A46cC623",
-    "name": "Rari Governance Token",
-    "symbol": "RGT",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/12900/thumb/Rari_Logo_Transparent.png?1613978014"
-  },
-  {
-    "chainId": 1,
-    "address": "0xFca59Cd816aB1eaD66534D82bc21E7515cE441CF",
-    "name": "Rarible",
-    "symbol": "RARI",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/11845/thumb/Rari.png?1594946953"
-  },
-  {
-    "chainId": 1,
-    "address": "0x6De037ef9aD2725EB40118Bb1702EBb27e4Aeb24",
-    "name": "Render Token",
-    "symbol": "RNDR",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/11636/thumb/rndr.png?1638840934"
-  },
-  {
-    "chainId": 1,
-    "address": "0x8f8221aFbB33998d8584A2B05749bA73c37a938a",
-    "name": "Request",
-    "symbol": "REQ",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/1031/thumb/Request_icon_green.png?1643250951"
-  },
-  {
-    "chainId": 1,
-    "address": "0x6123B0049F904d730dB3C36a31167D9d4121fA6B",
-    "name": "Ribbon Finance",
-    "symbol": "RBN",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/15823/thumb/RBN_64x64.png?1633529723"
-  },
-  {
-    "chainId": 1,
-    "address": "0xc770EEfAd204B5180dF6a14Ee197D99d808ee52d",
-    "name": "ShapeShift FOX Token",
-    "symbol": "FOX",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/9988/thumb/FOX.png?1574330622"
-  },
-  {
-    "chainId": 1,
-    "address": "0x95aD61b0a150d79219dCF64E1E6Cc01f0B64C4cE",
-    "name": "Shiba Inu",
-    "symbol": "SHIB",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/11939/thumb/shiba.png?1622619446"
-  },
-  {
-    "chainId": 1,
-    "address": "0x7C84e62859D0715eb77d1b1C4154Ecd6aBB21BEC",
-    "name": "Shping",
-    "symbol": "SHPING",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/2588/thumb/r_yabKKi_400x400.jpg?1639470164"
-  },
-  {
-    "chainId": 1,
-    "address": "0x00c83aeCC790e8a4453e5dD3B0B4b3680501a7A7",
-    "name": "SKALE",
-    "symbol": "SKL",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/13245/thumb/SKALE_token_300x300.png?1606789574"
-  },
-  {
-    "chainId": 1,
-    "address": "0x6F59e0461Ae5E2799F1fB3847f05a63B16d0DbF8",
-    "name": "ORCA Alliance",
-    "symbol": "ORCA",
-    "decimals": 18,
-    "logoURI": "https://s2.coinmarketcap.com/static/img/coins/64x64/5183.png"
-  },
-  {
-    "chainId": 1,
-    "address": "0x090185f2135308BaD17527004364eBcC2D37e5F6",
-    "name": "Spell Token",
-    "symbol": "SPELL",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/15861/thumb/abracadabra-3.png?1622544862"
-  },
-  {
-    "chainId": 1,
-    "address": "0x006BeA43Baa3f7A6f765F14f10A1a1b08334EF45",
-    "name": "Stox",
-    "symbol": "STX",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/1230/thumb/stox-token.png?1547035256"
-  },
-  {
-    "chainId": 1,
-    "address": "0x744d70FDBE2Ba4CF95131626614a1763DF805B9E",
-    "name": "Status",
-    "symbol": "SNT",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/779/thumb/status.png?1548610778"
-  },
-  {
-    "chainId": 1,
-    "address": "0xc1D204d77861dEf49b6E769347a883B15EC397Ff",
-    "name": "PayperEx",
-    "symbol": "PAX",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/1601/thumb/pax.png?1547035800"
-  },
-  {
-    "chainId": 1,
-    "address": "0x0763fdCCF1aE541A5961815C0872A8c5Bc6DE4d7",
-    "name": "SUKU",
-    "symbol": "SUKU",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/11969/thumb/UmfW5S6f_400x400.jpg?1596602238"
-  },
-  {
-    "chainId": 1,
-    "address": "0x6B3595068778DD592e39A122f4f5a5cF09C90fE2",
-    "name": "Sushi",
-    "symbol": "SUSHI",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/12271/thumb/512x512_Logo_no_chop.png?1606986688"
-  },
-  {
-    "chainId": 1,
-    "address": "0x88dF592F8eb5D7Bd38bFeF7dEb0fBc02cf3778a0",
-    "name": "Tellor",
-    "symbol": "TRB",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/9644/thumb/Blk_icon_current.png?1584980686"
-  },
-  {
-    "chainId": 1,
-    "address": "0xc7283b66Eb1EB5FB86327f08e1B5816b0720212B",
-    "name": "Tribe",
-    "symbol": "TRIBE",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/14575/thumb/tribe.PNG?1617487954"
-  },
-  {
-    "chainId": 1,
-    "address": "0x441761326490cACF7aF299725B6292597EE822c2",
-    "name": "Unifi Protocol DAO",
-    "symbol": "UNFI",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/13152/thumb/logo-2.png?1605748967"
-  },
-  {
-    "chainId": 1,
-    "address": "0x3C4B6E6e1eA3D4863700D7F76b36B7f3D3f13E3d",
-    "name": "Voyager Token",
-    "symbol": "VGX",
-    "decimals": 8,
-    "logoURI": "https://assets.coingecko.com/coins/images/794/thumb/Voyager-vgx.png?1575693595"
-  },
-  {
-    "chainId": 1,
-    "address": "0x55296f69f40Ea6d20E478533C15A6B08B654E758",
-    "name": "XYO Network",
-    "symbol": "XYO",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/4519/thumb/XYO_Network-logo.png?1547039819"
-  },
-  {
-    "chainId": 1,
-    "address": "0xCC8Fa225D80b9c7D42F96e9570156c65D6cAAa25",
-    "name": "Smooth Love Potion",
-    "symbol": "SLP",
-    "decimals": 0,
-    "logoURI": "https://assets.coingecko.com/coins/images/10366/thumb/SLP.png?1578640057"
-  },
-  {
-    "chainId": 1,
-    "address": "0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B",
-    "name": "Convex Finance",
-    "symbol": "CVX",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/15585/thumb/convex.png?1621256328"
-  },
-  {
-    "chainId": 1,
-    "address": "0x92D6C1e31e14520e676a687F0a93788B716BEff5",
-    "name": "dYdX",
-    "symbol": "DYDX",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/17500/thumb/hjnIm9bV.jpg?1628009360"
-  },
-  {
-    "chainId": 1,
-    "address": "0x3432B6A60D23Ca0dFCa7761B7ab56459D9C964D0",
-    "name": "Frax Share",
-    "symbol": "FXS",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/13423/thumb/frax_share.png?1608478989"
-  },
-  {
-    "chainId": 1,
-    "address": "0x1cEB5cB57C4D4E2b2433641b95Dd330A33185A44",
-    "name": "Keep3rV1",
-    "symbol": "KP3R",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/12966/thumb/kp3r_logo.jpg?1607057458"
-  },
-  {
-    "chainId": 1,
-    "address": "0x65Ef703f5594D2573eb71Aaf55BC0CB548492df4",
-    "name": "Multichain",
-    "symbol": "MULTI",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/22087/thumb/1_Wyot-SDGZuxbjdkaOeT2-A.png?1640764238"
-  },
-  {
-    "chainId": 1,
-    "address": "0x967da4048cD07aB37855c090aAF366e4ce1b9F48",
-    "name": "Ocean Protocol",
-    "symbol": "OCEAN",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/3687/thumb/ocean-protocol-logo.jpg?1547038686"
-  },
-  {
-    "chainId": 1,
-    "address": "0x45804880De22913dAFE09f4980848ECE6EcbAf78",
-    "name": "PAX Gold",
-    "symbol": "PAXG",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/9519/thumb/paxg.PNG?1568542565"
+    "address": "0xB98d4C97425d9908E66E53A6fDf673ACcA0BE986",
+    "name": "Arcblock",
+    "symbol": "ABT",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/2341/thumb/arcblock.png?1547036543"
   },
   {
     "chainId": 1,
@@ -1272,131 +48,19 @@
   },
   {
     "chainId": 1,
-    "address": "0x3D658390460295FB963f54dC0899cfb1c30776Df",
-    "name": "Circuits of Value",
-    "symbol": "COVAL",
-    "decimals": 8,
-    "logoURI": "https://assets.coingecko.com/coins/images/588/thumb/coval-logo.png?1599493950"
-  },
-  {
-    "chainId": 1,
-    "address": "0x3845badAde8e6dFF049820680d1F14bD3903a5d0",
-    "name": "The Sandbox",
-    "symbol": "SAND",
+    "address": "0x44108f0223A3C3028F5Fe7AEC7f9bb2E66beF82F",
+    "name": "Across Protocol Token",
+    "symbol": "ACX",
     "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/12129/thumb/sandbox_logo.jpg?1597397942"
+    "logoURI": "https://assets.coingecko.com/coins/images/28161/large/across-200x200.png?1696527165"
   },
   {
     "chainId": 1,
-    "address": "0x056Fd409E1d7A124BD7017459dFEa2F387b6d5Cd",
-    "name": "Gemini Dollar",
-    "symbol": "GUSD",
-    "decimals": 2,
-    "logoURI": "https://assets.coingecko.com/coins/images/5992/thumb/gemini-dollar-gusd.png?1536745278"
-  },
-  {
-    "chainId": 1,
-    "address": "0x18aAA7115705e8be94bfFEBDE57Af9BFc265B998",
-    "name": "Audius",
-    "symbol": "AUDIO",
+    "address": "0x8B1484d57abBE239bB280661377363b03c89CaEa",
+    "name": "ADI",
+    "symbol": "ADI",
     "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/12913/thumb/AudiusCoinLogo_2x.png?1603425727"
-  },
-  {
-    "chainId": 1,
-    "address": "0x64D91f12Ece7362F91A6f8E7940Cd55F05060b92",
-    "name": "ASH",
-    "symbol": "ASH",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/15714/thumb/omnPqaTY.png?1622820503"
-  },
-  {
-    "chainId": 1,
-    "address": "0x761D38e5ddf6ccf6Cf7c55759d5210750B5D60F3",
-    "name": "Dogelon Mars",
-    "symbol": "ELON",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/14962/thumb/6GxcPRo3_400x400.jpg?1619157413"
-  },
-  {
-    "chainId": 1,
-    "address": "0x4E15361FD6b4BB609Fa63C81A2be19d873717870",
-    "name": "Fantom",
-    "symbol": "FTM",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/4001/thumb/Fantom.png?1558015016"
-  },
-  {
-    "chainId": 1,
-    "address": "0xe28b3B32B6c345A34Ff64674606124Dd5Aceca30",
-    "name": "Injective",
-    "symbol": "INJ",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/12882/thumb/Secondary_Symbol.png?1628233237"
-  },
-  {
-    "chainId": 1,
-    "address": "0x5A98FcBEA516Cf06857215779Fd812CA3beF1B32",
-    "name": "Lido DAO",
-    "symbol": "LDO",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/13573/thumb/Lido_DAO.png?1609873644"
-  },
-  {
-    "chainId": 1,
-    "address": "0x99D8a9C45b2ecA8864373A26D1459e3Dff1e17F3",
-    "name": "Magic Internet Money",
-    "symbol": "MIM",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/16786/thumb/mimlogopng.png?1624979612"
-  },
-  {
-    "chainId": 1,
-    "address": "0x949D48EcA67b17269629c7194F4b727d4Ef9E5d6",
-    "name": "Merit Circle",
-    "symbol": "MC",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/19304/thumb/Db4XqML.png?1634972154"
-  },
-  {
-    "chainId": 1,
-    "address": "0xDf801468a808a32656D2eD2D2d80B72A129739f4",
-    "name": "Somnium Space CUBEs",
-    "symbol": "CUBE",
-    "decimals": 8,
-    "logoURI": "https://assets.coingecko.com/coins/images/10687/thumb/CUBE_icon.png?1617026861"
-  },
-  {
-    "chainId": 1,
-    "address": "0xAC51066d7bEC65Dc4589368da368b212745d63E8",
-    "name": "My Neighbor Alice",
-    "symbol": "ALICE",
-    "decimals": 6,
-    "logoURI": "https://assets.coingecko.com/coins/images/14375/thumb/alice_logo.jpg?1615782968"
-  },
-  {
-    "chainId": 1,
-    "address": "0x595832F8FC6BF59c85C527fEC3740A1b7a361269",
-    "name": "Power Ledger",
-    "symbol": "POWR",
-    "decimals": 6,
-    "logoURI": "https://assets.coingecko.com/coins/images/1104/thumb/power-ledger.png?1547035082"
-  },
-  {
-    "chainId": 1,
-    "address": "0x1aBaEA1f7C830bD89Acc67eC4af516284b1bC33c",
-    "name": "Euro Coin",
-    "symbol": "EURC",
-    "decimals": 6,
-    "logoURI": "https://assets.coingecko.com/coins/images/26045/thumb/euro-coin.png?1655394420"
-  },
-  {
-    "chainId": 1,
-    "address": "0xB98d4C97425d9908E66E53A6fDf673ACcA0BE986",
-    "name": "Arcblock",
-    "symbol": "ABT",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/2341/thumb/arcblock.png?1547036543"
+    "logoURI": "https://coin-images.coingecko.com/coins/images/68846/large/ADI_Token-min.png?1765296433"
   },
   {
     "chainId": 1,
@@ -1408,587 +72,19 @@
   },
   {
     "chainId": 1,
-    "address": "0x27702a26126e0B3702af63Ee09aC4d1A084EF628",
-    "name": "Aleph im",
-    "symbol": "ALEPH",
+    "address": "0x91Af0fBB28ABA7E31403Cb457106Ce79397FD4E6",
+    "name": "Aergo",
+    "symbol": "AERGO",
     "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/11676/thumb/Monochram-aleph.png?1608483725"
+    "logoURI": "https://assets.coingecko.com/coins/images/4490/thumb/aergo.png?1647696770"
   },
   {
     "chainId": 1,
-    "address": "0x6B0b3a982b4634aC68dD83a4DBF02311cE324181",
-    "name": "Alethea Artificial Liquid Intelligence",
-    "symbol": "ALI",
+    "address": "0xB528edBef013aff855ac3c50b381f253aF13b997",
+    "name": "Aevo",
+    "symbol": "AEVO",
     "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/22062/thumb/alethea-logo-transparent-colored.png?1642748848"
-  },
-  {
-    "chainId": 1,
-    "address": "0xa1faa113cbE53436Df28FF0aEe54275c13B40975",
-    "name": "Alpha Venture DAO",
-    "symbol": "ALPHA",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/12738/thumb/AlphaToken_256x256.png?1617160876"
-  },
-  {
-    "chainId": 1,
-    "address": "0x27054b13b1B798B345b591a4d22e6562d47eA75a",
-    "name": "AirSwap",
-    "symbol": "AST",
-    "decimals": 4,
-    "logoURI": "https://assets.coingecko.com/coins/images/1019/thumb/Airswap.png?1630903484"
-  },
-  {
-    "chainId": 1,
-    "address": "0xA2120b9e674d3fC3875f415A7DF52e382F141225",
-    "name": "Automata",
-    "symbol": "ATA",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/15985/thumb/ATA.jpg?1622535745"
-  },
-  {
-    "chainId": 1,
-    "address": "0x1A4b46696b2bB4794Eb3D4c26f1c55F9170fa4C5",
-    "name": "BitDAO",
-    "symbol": "BIT",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/17627/thumb/rI_YptK8.png?1653983088"
-  },
-  {
-    "chainId": 1,
-    "address": "0x42bBFa2e77757C645eeaAd1655E0911a7553Efbc",
-    "name": "Boba Network",
-    "symbol": "BOBA",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/20285/thumb/BOBA.png?1636811576"
-  },
-  {
-    "chainId": 1,
-    "address": "0x4Fabb145d64652a948d72533023f6E7A623C7C53",
-    "name": "Binance USD",
-    "symbol": "BUSD",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/9576/thumb/BUSD.png?1568947766",
-    "extensions": {
-      "bridgeInfo": {
-        "10": {
-          "tokenAddress": "0x9C9e5fD8bbc25984B178FdCE6117Defa39d2db39"
-        }
-      }
-    }
-  },
-  {
-    "chainId": 1,
-    "address": "0xAE12C5930881c53715B369ceC7606B70d8EB229f",
-    "name": "Coin98",
-    "symbol": "C98",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/17117/thumb/logo.png?1626412904"
-  },
-  {
-    "chainId": 1,
-    "address": "0x4F9254C83EB525f9FCf346490bbb3ed28a81C667",
-    "name": "Celer Network",
-    "symbol": "CELR",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/4379/thumb/Celr.png?1554705437"
-  },
-  {
-    "chainId": 1,
-    "address": "0x8A2279d4A90B6fe1C4B30fa660cC9f926797bAA2",
-    "name": "Chromia",
-    "symbol": "CHR",
-    "decimals": 6,
-    "logoURI": "https://assets.coingecko.com/coins/images/5000/thumb/Chromia.png?1559038018"
-  },
-  {
-    "chainId": 1,
-    "address": "0xD417144312DbF50465b1C641d016962017Ef6240",
-    "name": "Covalent",
-    "symbol": "CQT",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/14168/thumb/covalent-cqt.png?1624545218"
-  },
-  {
-    "chainId": 1,
-    "address": "0x081131434f93063751813C619Ecca9C4dC7862a3",
-    "name": "Mines of Dalarnia",
-    "symbol": "DAR",
-    "decimals": 6,
-    "logoURI": "https://assets.coingecko.com/coins/images/19837/thumb/dar.png?1636014223"
-  },
-  {
-    "chainId": 1,
-    "address": "0x3597bfD533a99c9aa083587B074434E61Eb0A258",
-    "name": "Dent",
-    "symbol": "DENT",
-    "decimals": 8,
-    "logoURI": "https://assets.coingecko.com/coins/images/1152/thumb/gLCEA2G.png?1604543239"
-  },
-  {
-    "chainId": 1,
-    "address": "0xfB7B4564402E5500dB5bB6d63Ae671302777C75a",
-    "name": "DexTools",
-    "symbol": "DEXT",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/11603/thumb/dext.png?1605790188"
-  },
-  {
-    "chainId": 1,
-    "address": "0x1494CA1F11D487c2bBe4543E90080AeBa4BA3C2b",
-    "name": "DeFi Pulse Index",
-    "symbol": "DPI",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/12465/thumb/defi_pulse_index_set.png?1600051053"
-  },
-  {
-    "chainId": 1,
-    "address": "0x3Ab6Ed69Ef663bd986Ee59205CCaD8A20F98b4c2",
-    "name": "Drep",
-    "symbol": "DREP",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/14578/thumb/KotgsCgS_400x400.jpg?1617094445"
-  },
-  {
-    "chainId": 1,
-    "address": "0x961C8c0B1aaD0c0b10a51FeF6a867E3091BCef17",
-    "name": "DeFi Yield Protocol",
-    "symbol": "DYP",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/13480/thumb/DYP_Logo_Symbol-8.png?1655809066"
-  },
-  {
-    "chainId": 1,
-    "address": "0xe6fd75ff38Adca4B97FBCD938c86b98772431867",
-    "name": "Elastos",
-    "symbol": "ELA",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/2780/thumb/Elastos.png?1597048112"
-  },
-  {
-    "chainId": 1,
-    "address": "0xd9Fcd98c322942075A5C3860693e9f4f03AAE07b",
-    "name": "Euler",
-    "symbol": "EUL",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/26149/thumb/YCvKDfl8_400x400.jpeg?1656041509"
-  },
-  {
-    "chainId": 1,
-    "address": "0xef3A930e1FfFFAcd2fc13434aC81bD278B0ecC8d",
-    "name": "Stafi",
-    "symbol": "FIS",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/12423/thumb/stafi_logo.jpg?1599730991"
-  },
-  {
-    "chainId": 1,
-    "address": "0x41545f8b9472D758bB669ed8EaEEEcD7a9C4Ec29",
-    "name": "Forta",
-    "symbol": "FORT",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/25060/thumb/Forta_lgo_%281%29.png?1655353696"
-  },
-  {
-    "chainId": 1,
-    "address": "0x853d955aCEf822Db058eb8505911ED77F175b99e",
-    "name": "Frax",
-    "symbol": "FRAX",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/13422/thumb/frax_logo.png?1608476506"
-  },
-  {
-    "chainId": 1,
-    "address": "0x5fAa989Af96Af85384b8a938c2EdE4A7378D9875",
-    "name": "Galxe",
-    "symbol": "GAL",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/24530/thumb/GAL-Token-Icon.png?1651483533"
-  },
-  {
-    "chainId": 1,
-    "address": "0x3F382DbD960E3a9bbCeaE22651E88158d2791550",
-    "name": "Aavegotchi",
-    "symbol": "GHST",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/12467/thumb/ghst_200.png?1600750321"
-  },
-  {
-    "chainId": 1,
-    "name": "HOPR",
-    "symbol": "HOPR",
-    "logoURI": "https://assets.coingecko.com/coins/images/14061/thumb/Shared_HOPR_logo_512px.png?1614073468",
-    "address": "0xF5581dFeFD8Fb0e4aeC526bE659CFaB1f8c781dA",
-    "decimals": 18
-  },
-  {
-    "chainId": 1,
-    "name": "Index Cooperative",
-    "symbol": "INDEX",
-    "logoURI": "https://assets.coingecko.com/coins/images/12729/thumb/index.png?1634894321",
-    "address": "0x0954906da0Bf32d5479e25f46056d22f08464cab",
-    "decimals": 18
-  },
-  {
-    "chainId": 1,
-    "name": "Geojam",
-    "symbol": "JAM",
-    "logoURI": "https://assets.coingecko.com/coins/images/24648/thumb/ey40AzBN_400x400.jpg?1648507272",
-    "address": "0x23894DC9da6c94ECb439911cAF7d337746575A72",
-    "decimals": 18
-  },
-  {
-    "chainId": 1,
-    "name": "Jupiter",
-    "symbol": "JUP",
-    "logoURI": "https://assets.coingecko.com/coins/images/10351/thumb/logo512.png?1632480932",
-    "address": "0x4B1E80cAC91e2216EEb63e29B957eB91Ae9C2Be8",
-    "decimals": 18
-  },
-  {
-    "chainId": 1,
-    "name": "SelfKey",
-    "symbol": "KEY",
-    "logoURI": "https://assets.coingecko.com/coins/images/2034/thumb/selfkey.png?1548608934",
-    "address": "0x4CC19356f2D37338b9802aa8E8fc58B0373296E7",
-    "decimals": 18
-  },
-  {
-    "chainId": 1,
-    "name": "League of Kingdoms",
-    "symbol": "LOKA",
-    "logoURI": "https://assets.coingecko.com/coins/images/22572/thumb/loka_64pix.png?1642643271",
-    "address": "0x61E90A50137E1F645c9eF4a0d3A4f01477738406",
-    "decimals": 18
-  },
-  {
-    "chainId": 1,
-    "name": "Liquity USD",
-    "symbol": "LUSD",
-    "logoURI": "https://assets.coingecko.com/coins/images/14666/thumb/Group_3.png?1617631327",
-    "address": "0x5f98805A4E8be255a32880FDeC7F6728C6568bA0",
-    "decimals": 18
-  },
-  {
-    "chainId": 1,
-    "name": "MATH",
-    "symbol": "MATH",
-    "logoURI": "https://assets.coingecko.com/coins/images/11335/thumb/2020-05-19-token-200.png?1589940590",
-    "address": "0x08d967bb0134F2d07f7cfb6E246680c53927DD30",
-    "decimals": 18
-  },
-  {
-    "chainId": 1,
-    "name": "Metis",
-    "symbol": "METIS",
-    "logoURI": "https://assets.coingecko.com/coins/images/15595/thumb/metis.jpeg?1660285312",
-    "address": "0x9E32b13ce7f2E80A01932B42553652E053D6ed8e",
-    "decimals": 18
-  },
-  {
-    "chainId": 1,
-    "name": "Monavale",
-    "symbol": "MONA",
-    "logoURI": "https://assets.coingecko.com/coins/images/13298/thumb/monavale_logo.jpg?1607232721",
-    "address": "0x275f5Ad03be0Fa221B4C6649B8AeE09a42D9412A",
-    "decimals": 18
-  },
-  {
-    "chainId": 1,
-    "name": "Metal",
-    "symbol": "MTL",
-    "logoURI": "https://assets.coingecko.com/coins/images/763/thumb/Metal.png?1592195010",
-    "address": "0xF433089366899D83a9f26A773D59ec7eCF30355e",
-    "decimals": 8
-  },
-  {
-    "chainId": 1,
-    "name": "Muse DAO",
-    "symbol": "MUSE",
-    "logoURI": "https://assets.coingecko.com/coins/images/13230/thumb/muse_logo.png?1606460453",
-    "address": "0xB6Ca7399B4F9CA56FC27cBfF44F4d2e4Eef1fc81",
-    "decimals": 18
-  },
-  {
-    "chainId": 1,
-    "name": "GensoKishi Metaverse",
-    "symbol": "MV",
-    "logoURI": "https://s2.coinmarketcap.com/static/img/coins/64x64/17704.png",
-    "address": "0xAE788F80F2756A86aa2F410C651F2aF83639B95b",
-    "decimals": 18
-  },
-  {
-    "chainId": 1,
-    "name": "MXC",
-    "symbol": "MXC",
-    "logoURI": "https://assets.coingecko.com/coins/images/4604/thumb/mxc.png?1655534336",
-    "address": "0x5Ca381bBfb58f0092df149bD3D243b08B9a8386e",
-    "decimals": 18
-  },
-  {
-    "chainId": 1,
-    "name": "Marlin",
-    "symbol": "POND",
-    "logoURI": "https://assets.coingecko.com/coins/images/8903/thumb/POND_200x200.png?1622515451",
-    "address": "0x57B946008913B82E4dF85f501cbAeD910e58D26C",
-    "decimals": 18
-  },
-  {
-    "chainId": 1,
-    "name": "PARSIQ",
-    "symbol": "PRQ",
-    "logoURI": "https://assets.coingecko.com/coins/images/11973/thumb/DsNgK0O.png?1596590280",
-    "address": "0x362bc847A3a9637d3af6624EeC853618a43ed7D2",
-    "decimals": 18
-  },
-  {
-    "chainId": 1,
-    "name": "pSTAKE Finance",
-    "symbol": "PSTAKE",
-    "logoURI": "https://assets.coingecko.com/coins/images/23931/thumb/PSTAKE_Dark.png?1645709930",
-    "address": "0xfB5c6815cA3AC72Ce9F5006869AE67f18bF77006",
-    "decimals": 18
-  },
-  {
-    "chainId": 1,
-    "name": "Qredo",
-    "symbol": "QRDO",
-    "logoURI": "https://assets.coingecko.com/coins/images/17541/thumb/qrdo.png?1630637735",
-    "address": "0x4123a133ae3c521FD134D7b13A2dEC35b56c2463",
-    "decimals": 8
-  },
-  {
-    "chainId": 1,
-    "name": "REVV",
-    "symbol": "REVV",
-    "logoURI": "https://assets.coingecko.com/coins/images/12373/thumb/REVV_TOKEN_Refined_2021_%281%29.png?1627652390",
-    "address": "0x557B933a7C2c45672B610F8954A3deB39a51A8Ca",
-    "decimals": 18
-  },
-  {
-    "chainId": 1,
-    "name": "Rook",
-    "symbol": "ROOK",
-    "logoURI": "https://assets.coingecko.com/coins/images/13005/thumb/keeper_dao_logo.jpg?1604316506",
-    "address": "0xfA5047c9c78B8877af97BDcb85Db743fD7313d4a",
-    "decimals": 18
-  },
-  {
-    "chainId": 1,
-    "name": "Stargate Finance",
-    "symbol": "STG",
-    "logoURI": "https://assets.coingecko.com/coins/images/24413/thumb/STG_LOGO.png?1647654518",
-    "address": "0xAf5191B0De278C7286d6C7CC6ab6BB8A73bA2Cd6",
-    "decimals": 18
-  },
-  {
-    "chainId": 1,
-    "name": "SWFTCOIN",
-    "symbol": "SWFTC",
-    "logoURI": "https://assets.coingecko.com/coins/images/2346/thumb/SWFTCoin.jpg?1618392022",
-    "address": "0x0bb217E40F8a5Cb79Adf04E1aAb60E5abd0dfC1e",
-    "decimals": 8
-  },
-  {
-    "chainId": 1,
-    "name": "Swipe",
-    "symbol": "SXP",
-    "logoURI": "https://assets.coingecko.com/coins/images/9368/thumb/swipe.png?1566792311",
-    "address": "0x8CE9137d39326AD0cD6491fb5CC0CbA0e089b6A9",
-    "decimals": 18
-  },
-  {
-    "chainId": 1,
-    "name": "Sylo",
-    "symbol": "SYLO",
-    "logoURI": "https://assets.coingecko.com/coins/images/6430/thumb/SYLO.svg?1589527756",
-    "address": "0xf293d23BF2CDc05411Ca0edDD588eb1977e8dcd4",
-    "decimals": 18
-  },
-  {
-    "chainId": 1,
-    "name": "Threshold Network",
-    "symbol": "T",
-    "logoURI": "https://assets.coingecko.com/coins/images/22228/thumb/nFPNiSbL_400x400.jpg?1641220340",
-    "address": "0xCdF7028ceAB81fA0C6971208e83fa7872994beE5",
-    "decimals": 18
-  },
-  {
-    "chainId": 1,
-    "name": "ChronoTech",
-    "symbol": "TIME",
-    "logoURI": "https://assets.coingecko.com/coins/images/604/thumb/time-32x32.png?1627130666",
-    "address": "0x485d17A6f1B8780392d53D64751824253011A260",
-    "decimals": 8
-  },
-  {
-    "chainId": 1,
-    "name": "Alien Worlds",
-    "symbol": "TLM",
-    "logoURI": "https://assets.coingecko.com/coins/images/14676/thumb/kY-C4o7RThfWrDQsLCAG4q4clZhBDDfJQVhWUEKxXAzyQYMj4Jmq1zmFwpRqxhAJFPOa0AsW_PTSshoPuMnXNwq3rU7Imp15QimXTjlXMx0nC088mt1rIwRs75GnLLugWjSllxgzvQ9YrP4tBgclK4_rb17hjnusGj_c0u2fx0AvVokjSNB-v2poTj0xT9BZRCbzRE3-lF1.jpg?1617700061",
-    "address": "0x888888848B652B3E3a0f34c96E00EEC0F3a23F72",
-    "decimals": 4
-  },
-  {
-    "chainId": 1,
-    "name": "TE FOOD",
-    "symbol": "TONE",
-    "logoURI": "https://assets.coingecko.com/coins/images/2325/thumb/tec.png?1547036538",
-    "address": "0x2Ab6Bb8408ca3199B8Fa6C92d5b455F820Af03c4",
-    "decimals": 18
-  },
-  {
-    "chainId": 1,
-    "name": "The Virtua Kolect",
-    "symbol": "TVK",
-    "logoURI": "https://assets.coingecko.com/coins/images/13330/thumb/virtua_original.png?1656043619",
-    "address": "0xd084B83C305daFD76AE3E1b4E1F1fe2eCcCb3988",
-    "decimals": 18
-  },
-  {
-    "chainId": 1,
-    "name": "Wrapped Ampleforth",
-    "symbol": "WAMPL",
-    "logoURI": "https://assets.coingecko.com/coins/images/20825/thumb/photo_2021-11-25_02-05-11.jpg?1637811951",
-    "address": "0xEDB171C18cE90B633DB442f2A6F72874093b49Ef",
-    "decimals": 18
-  },
-  {
-    "chainId": 1,
-    "name": "Wrapped Centrifuge",
-    "symbol": "WCFG",
-    "logoURI": "https://assets.coingecko.com/coins/images/17106/thumb/WCFG.jpg?1626266462",
-    "address": "0xc221b7E65FfC80DE234bbB6667aBDd46593D34F0",
-    "decimals": 18
-  },
-  {
-    "chainId": 1,
-    "name": "WOO Network",
-    "symbol": "WOO",
-    "logoURI": "https://assets.coingecko.com/coins/images/12921/thumb/w2UiemF__400x400.jpg?1603670367",
-    "address": "0x4691937a7508860F876c9c0a2a617E7d9E945D4B",
-    "decimals": 18
-  },
-  {
-    "chainId": 1,
-    "name": "Chain",
-    "symbol": "XCN",
-    "logoURI": "https://assets.coingecko.com/coins/images/24210/thumb/Chain_icon_200x200.png?1646895054",
-    "address": "0xA2cd3D43c775978A96BdBf12d733D5A1ED94fb18",
-    "decimals": 18
-  },
-  {
-    "chainId": 1,
-    "name": "Yield Guild Games",
-    "symbol": "YGG",
-    "logoURI": "https://assets.coingecko.com/coins/images/17358/thumb/le1nzlO6_400x400.jpg?1632465691",
-    "address": "0x25f8087EAD173b73D6e8B84329989A8eEA16CF73",
-    "decimals": 18
-  },
-  {
-    "chainId": 1,
-    "address": "0x23B608675a2B2fB1890d3ABBd85c5775c51691d5",
-    "name": "Unisocks",
-    "symbol": "SOCKS",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/10717/thumb/qFrcoiM.png?1582525244"
-  },
-  {
-    "chainId": 1,
-    "address": "0x5283D291DBCF85356A21bA090E6db59121208b44",
-    "name": "Blur",
-    "symbol": "BLUR",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/28453/large/blur.png?1670745921"
-  },
-  {
-    "chainId": 1,
-    "address": "0x467719aD09025FcC6cF6F8311755809d45a5E5f3",
-    "name": "Axelar",
-    "symbol": "AXL",
-    "decimals": 6,
-    "logoURI": "https://assets.coingecko.com/coins/images/27277/large/V-65_xQ1_400x400.jpeg",
-    "extensions": {
-      "bridgeInfo": {
-        "42161": {
-          "tokenAddress": "0x23ee2343B892b1BB63503a4FAbc840E0e2C6810f"
-        }
-      }
-    }
-  },
-  {
-    "chainId": 1,
-    "address": "0x767FE9EDC9E0dF98E07454847909b5E959D7ca0E",
-    "name": "Illuvium",
-    "symbol": "ILV",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/14468/large/ILV.JPG"
-  },
-  {
-    "chainId": 1,
-    "address": "0xb3999F658C0391d94A37f7FF328F3feC942BcADC",
-    "name": "Hashflow",
-    "symbol": "HFT",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/26136/large/hashflow-icon-cmc.png"
-  },
-  {
-    "chainId": 1,
-    "name": "Arbitrum",
-    "address": "0xB50721BCf8d664c30412Cfbc6cf7a15145234ad1",
-    "symbol": "ARB",
-    "decimals": 18,
-    "logoURI": "https://arbitrum.foundation/logo.png"
-  },
-  {
-    "chainId": 1,
-    "address": "0xBe9895146f7AF43049ca1c1AE358B0541Ea49704",
-    "name": "Coinbase Wrapped Staked ETH",
-    "symbol": "cbETH",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/27008/large/cbeth.png"
-  },
-  {
-    "chainId": 1,
-    "address": "0x6982508145454Ce325dDbE47a25d4ec3d2311933",
-    "name": "Pepe",
-    "symbol": "PEPE",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/29850/large/pepe-token.jpeg?1682922725"
-  },
-  {
-    "chainId": 1,
-    "address": "0xb23d80f5FefcDDaa212212F028021B41DEd428CF",
-    "name": "Prime",
-    "symbol": "PRIME",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/29053/large/PRIMELOGOOO.png?1676976222"
-  },
-  {
-    "chainId": 1,
-    "address": "0x6c3ea9036406852006290770BEdFcAbA0e23A0e8",
-    "name": "PayPal USD",
-    "symbol": "PYUSD",
-    "decimals": 6,
-    "logoURI": "https://assets.coingecko.com/coins/images/31212/large/PYUSD_Logo_%282%29.png?1691458314"
-  },
-  {
-    "chainId": 1,
-    "address": "0x3294395e62F4eB6aF3f1Fcf89f5602D90Fb3Ef69",
-    "name": "Celo native asset (Wormhole)",
-    "symbol": "CELO",
-    "decimals": 18,
-    "logoURI": "https://raw.githubusercontent.com/wormhole-foundation/wormhole-token-list/main/assets/celo_wh.png",
-    "extensions": {
-      "bridgeInfo": {
-        "10": {
-          "tokenAddress": "0x9b88D293b7a791E40d36A39765FFd5A1B9b5c349"
-        },
-        "42161": {
-          "tokenAddress": "0x4E51aC49bC5e2d87e0EF713E9e5AB2D71EF4F336"
-        }
-      }
-    }
+    "logoURI": "https://assets.coingecko.com/coins/images/35893/standard/aevo.png"
   },
   {
     "chainId": 1,
@@ -2016,106 +112,67 @@
   },
   {
     "chainId": 1,
-    "address": "0x70e8dE73cE538DA2bEEd35d14187F6959a8ecA96",
-    "name": "XSGD",
-    "symbol": "XSGD",
+    "address": "0x32353A6C91143bfd6C7d363B546e62a9A2489A20",
+    "name": "Adventure Gold",
+    "symbol": "AGLD",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/18125/thumb/lpgblc4h_400x400.jpg?1630570955"
+  },
+  {
+    "chainId": 1,
+    "address": "0x626E8036dEB333b408Be468F951bdB42433cBF18",
+    "name": "AIOZ Network",
+    "symbol": "AIOZ",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/14631/thumb/aioz_logo.png?1617413126"
+  },
+  {
+    "chainId": 1,
+    "address": "0xdBdb4d16EdA451D0503b854CF79D55697F90c8DF",
+    "name": "Alchemix",
+    "symbol": "ALCX",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/14113/thumb/Alchemix.png?1614409874"
+  },
+  {
+    "chainId": 1,
+    "address": "0x27702a26126e0B3702af63Ee09aC4d1A084EF628",
+    "name": "Aleph im",
+    "symbol": "ALEPH",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/11676/thumb/Monochram-aleph.png?1608483725"
+  },
+  {
+    "chainId": 1,
+    "address": "0x6B0b3a982b4634aC68dD83a4DBF02311cE324181",
+    "name": "Alethea Artificial Liquid Intelligence",
+    "symbol": "ALI",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/22062/thumb/alethea-logo-transparent-colored.png?1642748848"
+  },
+  {
+    "chainId": 1,
+    "address": "0xAC51066d7bEC65Dc4589368da368b212745d63E8",
+    "name": "My Neighbor Alice",
+    "symbol": "ALICE",
     "decimals": 6,
-    "logoURI": "https://assets.coingecko.com/coins/images/12832/standard/StraitsX_Singapore_Dollar_%28XSGD%29_Token_Logo.png?1696512623",
-    "extensions": {
-      "bridgeInfo": {
-        "137": {
-          "tokenAddress": "0xDC3326e71D45186F113a2F448984CA0e8D201995"
-        }
-      }
-    }
+    "logoURI": "https://assets.coingecko.com/coins/images/14375/thumb/alice_logo.jpg?1615782968"
   },
   {
     "chainId": 1,
-    "address": "0x64Bc2cA1Be492bE7185FAA2c8835d9b824c8a194",
-    "name": "Big Time",
-    "symbol": "BIGTIME",
+    "address": "0x8408D45b61f5823298F19a09B53b7339c0280489",
+    "name": "Allora",
+    "symbol": "ALLO",
     "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/32251/standard/-6136155493475923781_121.jpg?1696998691"
+    "logoURI": "https://coin-images.coingecko.com/coins/images/70609/large/allo-token.png?1763451165"
   },
   {
     "chainId": 1,
-    "address": "0xd1d2Eb1B1e90B638588728b4130137D262C87cae",
-    "name": "GALA",
-    "symbol": "GALA",
-    "decimals": 8,
-    "logoURI": "https://assets.coingecko.com/coins/images/12493/standard/GALA-COINGECKO.png?1696512310"
-  },
-  {
-    "chainId": 1,
-    "address": "0xfAbA6f8e4a5E8Ab82F62fe7C39859FA577269BE3",
-    "name": "Ondo Finance",
-    "symbol": "ONDO",
+    "address": "0xa1faa113cbE53436Df28FF0aEe54275c13B40975",
+    "name": "Alpha Venture DAO",
+    "symbol": "ALPHA",
     "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/26580/standard/ONDO.png?1696525656"
-  },
-  {
-    "chainId": 1,
-    "address": "0xf091867EC603A6628eD83D274E835539D82e9cc8",
-    "name": "Zetachain",
-    "symbol": "Zeta",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/26718/standard/Twitter_icon.png?1696525788"
-  },
-  {
-    "chainId": 1,
-    "address": "0xCa14007Eff0dB1f8135f4C25B34De49AB0d42766",
-    "name": "Starknet",
-    "symbol": "STRK",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/26433/standard/starknet.png?1696525507"
-  },
-  {
-    "chainId": 1,
-    "address": "0x6E2a43be0B1d33b726f0CA3b8de60b3482b8b050",
-    "name": "Arkham",
-    "symbol": "ARKM",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/30929/standard/Arkham_Logo_CG.png?1696529771"
-  },
-  {
-    "chainId": 1,
-    "address": "0x62D0A8458eD7719FDAF978fe5929C6D342B0bFcE",
-    "name": "Beam",
-    "symbol": "BEAM",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/32417/standard/chain-logo.png?1698114384"
-  },
-  {
-    "chainId": 1,
-    "address": "0x36E66fbBce51e4cD5bd3C62B637Eb411b18949D4",
-    "name": "Omni Network",
-    "symbol": "OMNI",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/36465/standard/Symbol-Color.png?1711511095"
-  },
-  {
-    "chainId": 1,
-    "address": "0x5aFE3855358E112B5647B952709E6165e1c1eEEe",
-    "name": "Safe",
-    "symbol": "SAFE",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/27032/standard/Artboard_1_copy_8circle-1.png?1696526084"
-  },
-  {
-    "chainId": 1,
-    "address": "0x57e114B691Db790C35207b2e685D4A43181e6061",
-    "name": "Ethena",
-    "symbol": "ENA",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/36530/standard/ethena.png"
-  },
-  {
-    "chainId": 1,
-    "address": "0xFe0c30065B384F05761f15d0CC899D4F9F9Cc0eB",
-    "name": "Ether.fi",
-    "symbol": "ETHFI",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/35958/standard/etherfi.jpeg"
+    "logoURI": "https://assets.coingecko.com/coins/images/12738/thumb/AlphaToken_256x256.png?1617160876"
   },
   {
     "chainId": 1,
@@ -2127,50 +184,1250 @@
   },
   {
     "chainId": 1,
-    "address": "0xB528edBef013aff855ac3c50b381f253aF13b997",
-    "name": "Aevo",
-    "symbol": "AEVO",
+    "address": "0xfF20817765cB7f73d4bde2e66e067E58D11095C2",
+    "name": "Amp",
+    "symbol": "AMP",
     "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/35893/standard/aevo.png"
+    "logoURI": "https://assets.coingecko.com/coins/images/12409/thumb/amp-200x200.png?1599625397"
   },
   {
     "chainId": 1,
-    "address": "0x0D3CbED3f69EE050668ADF3D9Ea57241cBa33A2B",
-    "name": "PlayDapp",
-    "symbol": "PDA",
+    "address": "0x8290333ceF9e6D528dD5618Fb97a76f268f3EDD4",
+    "name": "Ankr",
+    "symbol": "ANKR",
     "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/14316/standard/PDA-symbol.png?1710234068"
+    "logoURI": "https://assets.coingecko.com/coins/images/4324/thumb/U85xTl2.png?1608111978"
+  },
+  {
+    "name": "Aragon",
+    "address": "0xa117000000f279D81A1D3cc75430fAA017FA5A2e",
+    "symbol": "ANT",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://assets.coingecko.com/coins/images/681/thumb/JelZ58cv_400x400.png?1601449653"
   },
   {
     "chainId": 1,
-    "address": "0x1Bbe973BeF3a977Fc51CbED703E8ffDEfE001Fed",
-    "name": "Portal",
-    "symbol": "PORTAL",
+    "address": "0x4d224452801ACEd8B2F0aebE155379bb5D594381",
+    "name": "ApeCoin",
+    "symbol": "APE",
     "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/35436/standard/portal.jpeg"
+    "logoURI": "https://assets.coingecko.com/coins/images/24383/small/apecoin.jpg?1647476455"
   },
   {
     "chainId": 1,
-    "address": "0x8E870D67F660D95d5be530380D0eC0bd388289E1",
-    "name": "Pax Dollar",
-    "symbol": "USDP",
+    "address": "0x0b38210ea11411557c13457D4dA7dC6ea731B88a",
+    "name": "API3",
+    "symbol": "API3",
     "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/6013/standard/Pax_Dollar.png?1696506427"
+    "logoURI": "https://assets.coingecko.com/coins/images/13256/thumb/api3.jpg?1606751424"
   },
   {
     "chainId": 1,
-    "address": "0x6985884C4392D348587B19cb9eAAf157F13271cd",
-    "name": "LayerZero",
-    "symbol": "ZRO",
+    "address": "0x5A9610919f5e81183823A2be4Bd1BeB2B4da2a20",
+    "name": "aPriori",
+    "symbol": "APR",
     "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/28206/standard/ftxG9_TJ_400x400.jpeg?1696527208",
+    "logoURI": "https://coin-images.coingecko.com/coins/images/70220/large/logo-icon-Gradient.png?1761118006"
+  },
+  {
+    "chainId": 1,
+    "address": "0x594DaaD7D77592a2b97b725A7AD59D7E188b5bFa",
+    "name": "Apu Apustaja",
+    "symbol": "APU",
+    "decimals": 18,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/35986/large/200x200.png?1710308147"
+  },
+  {
+    "chainId": 1,
+    "name": "Arbitrum",
+    "address": "0xB50721BCf8d664c30412Cfbc6cf7a15145234ad1",
+    "symbol": "ARB",
+    "decimals": 18,
+    "logoURI": "https://arbitrum.foundation/logo.png"
+  },
+  {
+    "chainId": 1,
+    "address": "0x6E2a43be0B1d33b726f0CA3b8de60b3482b8b050",
+    "name": "Arkham",
+    "symbol": "ARKM",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/30929/standard/Arkham_Logo_CG.png?1696529771"
+  },
+  {
+    "chainId": 1,
+    "address": "0xBA50933C268F567BDC86E1aC131BE072C6B0b71a",
+    "name": "ARPA Chain",
+    "symbol": "ARPA",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/8506/thumb/9u0a23XY_400x400.jpg?1559027357"
+  },
+  {
+    "chainId": 1,
+    "address": "0x64D91f12Ece7362F91A6f8E7940Cd55F05060b92",
+    "name": "ASH",
+    "symbol": "ASH",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/15714/thumb/omnPqaTY.png?1622820503"
+  },
+  {
+    "chainId": 1,
+    "address": "0x2565ae0385659badCada1031DB704442E1b69982",
+    "name": "Assemble Protocol",
+    "symbol": "ASM",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/11605/thumb/gpvrlkSq_400x400_%281%29.jpg?1591775789"
+  },
+  {
+    "chainId": 1,
+    "address": "0x27054b13b1B798B345b591a4d22e6562d47eA75a",
+    "name": "AirSwap",
+    "symbol": "AST",
+    "decimals": 4,
+    "logoURI": "https://assets.coingecko.com/coins/images/1019/thumb/Airswap.png?1630903484"
+  },
+  {
+    "chainId": 1,
+    "address": "0xA2120b9e674d3fC3875f415A7DF52e382F141225",
+    "name": "Automata",
+    "symbol": "ATA",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/15985/thumb/ATA.jpg?1622535745"
+  },
+  {
+    "chainId": 1,
+    "address": "0xbe0Ed4138121EcFC5c0E56B40517da27E6c5226B",
+    "name": "Aethir Token",
+    "symbol": "ATH",
+    "decimals": 18,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/36179/large/logogram_circle_dark_green_vb_green_(1).png?1718232706"
+  },
+  {
+    "chainId": 1,
+    "address": "0xA9B1Eb5908CfC3cdf91F9B8B3a74108598009096",
+    "name": "Bounce",
+    "symbol": "AUCTION",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/13860/thumb/1_KtgpRIJzuwfHe0Rl0avP_g.jpeg?1612412025"
+  },
+  {
+    "chainId": 1,
+    "address": "0x4cCe605eD955295432958d8951D0B176C10720d5",
+    "name": "AUDD",
+    "symbol": "AUDD",
+    "decimals": 6,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/33263/large/AUDD-Logo-Blue_512.png?1701319895"
+  },
+  {
+    "chainId": 1,
+    "address": "0x18aAA7115705e8be94bfFEBDE57Af9BFc265B998",
+    "name": "Audius",
+    "symbol": "AUDIO",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/12913/thumb/AudiusCoinLogo_2x.png?1603425727"
+  },
+  {
+    "chainId": 1,
+    "address": "0x845576c64f9754CF09d87e45B720E82F3EeF522C",
+    "name": "Artverse Token",
+    "symbol": "AVT",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/19727/thumb/ewnektoB_400x400.png?1635767094"
+  },
+  {
+    "chainId": 1,
+    "address": "0x467719aD09025FcC6cF6F8311755809d45a5E5f3",
+    "name": "Axelar",
+    "symbol": "AXL",
+    "decimals": 6,
+    "logoURI": "https://assets.coingecko.com/coins/images/27277/large/V-65_xQ1_400x400.jpeg",
     "extensions": {
       "bridgeInfo": {
         "42161": {
-          "tokenAddress": "0x6985884C4392D348587B19cb9eAAf157F13271cd"
+          "tokenAddress": "0x23ee2343B892b1BB63503a4FAbc840E0e2C6810f"
         }
       }
     }
+  },
+  {
+    "chainId": 1,
+    "address": "0xBB0E17EF65F82Ab018d8EDd776e8DD940327B28b",
+    "name": "Axie Infinity",
+    "symbol": "AXS",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/13029/thumb/axie_infinity_logo.png?1604471082"
+  },
+  {
+    "chainId": 1,
+    "address": "0xA27EC0006e59f245217Ff08CD52A7E8b169E62D2",
+    "name": "Aztec",
+    "symbol": "AZTEC",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/70681/large/aztec.png?1763091883"
+  },
+  {
+    "chainId": 1,
+    "address": "0x3472A5A71965499acd81997a54BBA8D852C6E53d",
+    "name": "Badger DAO",
+    "symbol": "BADGER",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/13287/thumb/badger_dao_logo.jpg?1607054976"
+  },
+  {
+    "name": "Balancer",
+    "address": "0xba100000625a3754423978a60c9317c58a424e3D",
+    "symbol": "BAL",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xba100000625a3754423978a60c9317c58a424e3D/logo.png"
+  },
+  {
+    "chainId": 1,
+    "address": "0xBA11D00c5f74255f56a5E366F4F77f5A186d7f55",
+    "name": "Band Protocol",
+    "symbol": "BAND",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/9545/thumb/band-protocol.png?1568730326"
+  },
+  {
+    "chainId": 1,
+    "address": "0xf0DB65D17e30a966C2ae6A21f6BBA71cea6e9754",
+    "name": "Lombard",
+    "symbol": "BARD",
+    "decimals": 18,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/68404/large/bard.png?1755657543"
+  },
+  {
+    "chainId": 1,
+    "address": "0x0D8775F648430679A709E98d2b0Cb6250d2887EF",
+    "name": "Basic Attention Token",
+    "symbol": "BAT",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/677/thumb/basic-attention-token.png?1547034427"
+  },
+  {
+    "chainId": 1,
+    "address": "0x62D0A8458eD7719FDAF978fe5929C6D342B0bFcE",
+    "name": "Beam",
+    "symbol": "BEAM",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/32417/standard/chain-logo.png?1698114384"
+  },
+  {
+    "chainId": 1,
+    "address": "0xF17e65822b568B3903685a7c9F496CF7656Cc6C2",
+    "name": "Biconomy",
+    "symbol": "BICO",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/21061/thumb/biconomy_logo.jpg?1638269749"
+  },
+  {
+    "chainId": 1,
+    "address": "0x64Bc2cA1Be492bE7185FAA2c8835d9b824c8a194",
+    "name": "Big Time",
+    "symbol": "BIGTIME",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/32251/standard/-6136155493475923781_121.jpg?1696998691"
+  },
+  {
+    "chainId": 1,
+    "address": "0xb1110919016846972056AB995054D65560D5f05E",
+    "name": "Billions",
+    "symbol": "BILL",
+    "decimals": 18,
+    "logoURI": "https://s2.coinmarketcap.com/static/img/coins/64x64/39545.png"
+  },
+  {
+    "chainId": 1,
+    "address": "0xcb1592591996765Ec0eFc1f92599A19767ee5ffA",
+    "name": "BIO",
+    "symbol": "BIO",
+    "decimals": 18,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/53022/large/bio.jpg?1735011002"
+  },
+  {
+    "chainId": 1,
+    "address": "0x1A4b46696b2bB4794Eb3D4c26f1c55F9170fa4C5",
+    "name": "BitDAO",
+    "symbol": "BIT",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/17627/thumb/rI_YptK8.png?1653983088"
+  },
+  {
+    "chainId": 1,
+    "address": "0x72e4f9F808C49A2a61dE9C5896298920Dc4EEEa9",
+    "name": "HarryPotterObamaSonic10Inu",
+    "symbol": "BITCOIN",
+    "decimals": 8,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/30323/large/hpos10i_logo_casino_night-dexview.png?1696529224"
+  },
+  {
+    "chainId": 1,
+    "address": "0xd8A271974E8EdAE9D7b58e3370dc1669427503F4",
+    "name": "Fluent",
+    "symbol": "BLEND",
+    "decimals": 18
+  },
+  {
+    "chainId": 1,
+    "address": "0x5283D291DBCF85356A21bA090E6db59121208b44",
+    "name": "Blur",
+    "symbol": "BLUR",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/28453/large/blur.png?1670745921"
+  },
+  {
+    "chainId": 1,
+    "address": "0x5732046A883704404F284Ce41FfADd5b007FD668",
+    "name": "Bluzelle",
+    "symbol": "BLZ",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/2848/thumb/ColorIcon_3x.png?1622516510"
+  },
+  {
+    "name": "Bancor Network Token",
+    "address": "0x1F573D6Fb3F13d689FF844B4cE37794d79a7FF1C",
+    "symbol": "BNT",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1F573D6Fb3F13d689FF844B4cE37794d79a7FF1C/logo.png"
+  },
+  {
+    "chainId": 1,
+    "address": "0x42bBFa2e77757C645eeaAd1655E0911a7553Efbc",
+    "name": "Boba Network",
+    "symbol": "BOBA",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/20285/thumb/BOBA.png?1636811576"
+  },
+  {
+    "chainId": 1,
+    "address": "0xC9746F73cC33a36c2cD55b8aEFD732586946Cedd",
+    "name": "BOB",
+    "symbol": "BOBBOB",
+    "decimals": 18,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/54720/large/BOB_symbol_colour.png?1741195397"
+  },
+  {
+    "chainId": 1,
+    "address": "0x0391D2021f89DC339F60Fff84546EA23E337750f",
+    "name": "BarnBridge",
+    "symbol": "BOND",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/12811/thumb/barnbridge.jpg?1602728853"
+  },
+  {
+    "chainId": 1,
+    "address": "0x086F405146Ce90135750Bbec9A063a8B20A8bfFb",
+    "name": "Brevis",
+    "symbol": "BREV",
+    "decimals": 18,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/71219/large/brevis.png?1766454723"
+  },
+  {
+    "chainId": 1,
+    "address": "0x799ebfABE77a6E34311eeEe9825190B9ECe32824",
+    "name": "Braintrust",
+    "symbol": "BTRST",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/18100/thumb/braintrust.PNG?1630475394"
+  },
+  {
+    "chainId": 1,
+    "address": "0x4Fabb145d64652a948d72533023f6E7A623C7C53",
+    "name": "Binance USD",
+    "symbol": "BUSD",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/9576/thumb/BUSD.png?1568947766",
+    "extensions": {
+      "bridgeInfo": {
+        "10": {
+          "tokenAddress": "0x9C9e5fD8bbc25984B178FdCE6117Defa39d2db39"
+        }
+      }
+    }
+  },
+  {
+    "chainId": 1,
+    "address": "0xAE12C5930881c53715B369ceC7606B70d8EB229f",
+    "name": "Coin98",
+    "symbol": "C98",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/17117/thumb/logo.png?1626412904"
+  },
+  {
+    "name": "PancakeSwap",
+    "address": "0x152649eA73beAb28c5b49B26eb48f7EAD6d4c898",
+    "symbol": "CAKE",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/12632/large/pancakeswap-cake-logo_%281%29.png?1696512440"
+  },
+  {
+    "chainId": 1,
+    "name": "Coinbase Wrapped BTC",
+    "address": "0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf",
+    "symbol": "cbBTC",
+    "decimals": 8,
+    "logoURI": "https://assets.coingecko.com/coins/images/40143/standard/cbbtc.webp"
+  },
+  {
+    "chainId": 1,
+    "address": "0xBe9895146f7AF43049ca1c1AE358B0541Ea49704",
+    "name": "Coinbase Wrapped Staked ETH",
+    "symbol": "cbETH",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/27008/large/cbeth.png"
+  },
+  {
+    "chainId": 1,
+    "address": "0x3294395e62F4eB6aF3f1Fcf89f5602D90Fb3Ef69",
+    "name": "Celo native asset (Wormhole)",
+    "symbol": "CELO",
+    "decimals": 18,
+    "logoURI": "https://raw.githubusercontent.com/wormhole-foundation/wormhole-token-list/main/assets/celo_wh.png",
+    "extensions": {
+      "bridgeInfo": {
+        "10": {
+          "tokenAddress": "0x9b88D293b7a791E40d36A39765FFd5A1B9b5c349"
+        },
+        "42161": {
+          "tokenAddress": "0x4E51aC49bC5e2d87e0EF713E9e5AB2D71EF4F336"
+        }
+      }
+    }
+  },
+  {
+    "chainId": 1,
+    "address": "0x4F9254C83EB525f9FCf346490bbb3ed28a81C667",
+    "name": "Celer Network",
+    "symbol": "CELR",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/4379/thumb/Celr.png?1554705437"
+  },
+  {
+    "chainId": 1,
+    "address": "0xcccCCCcCCC33D538DBC2EE4fEab0a7A1FF4e8A94",
+    "name": "Centrifuge",
+    "symbol": "CFG",
+    "decimals": 18,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/55913/large/centrifuge.jpg?1747707741"
+  },
+  {
+    "chainId": 1,
+    "address": "0x8A2279d4A90B6fe1C4B30fa660cC9f926797bAA2",
+    "name": "Chromia",
+    "symbol": "CHR",
+    "decimals": 6,
+    "logoURI": "https://assets.coingecko.com/coins/images/5000/thumb/Chromia.png?1559038018"
+  },
+  {
+    "chainId": 1,
+    "address": "0x3506424F91fD33084466F402d5D97f05F8e3b4AF",
+    "name": "Chiliz",
+    "symbol": "CHZ",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/8834/thumb/Chiliz.png?1561970540"
+  },
+  {
+    "chainId": 1,
+    "address": "0x80C62FE4487E1351b47Ba49809EBD60ED085bf52",
+    "name": "Clover Finance",
+    "symbol": "CLV",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/15278/thumb/clover.png?1645084454"
+  },
+  {
+    "name": "Compound",
+    "address": "0xc00e94Cb662C3520282E6f5717214004A7f26888",
+    "symbol": "COMP",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xc00e94Cb662C3520282E6f5717214004A7f26888/logo.png"
+  },
+  {
+    "chainId": 1,
+    "address": "0x9F0C013016E8656bC256f948CD4B79ab25c7b94D",
+    "name": "mETH Protocol",
+    "symbol": "COOK",
+    "decimals": 18,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/50969/large/Logomark-Gradient_Official.png?1729620221"
+  },
+  {
+    "chainId": 1,
+    "address": "0x44f49ff0da2498bCb1D3Dc7C0f999578F67FD8C6",
+    "name": "Corn",
+    "symbol": "CORN",
+    "decimals": 18,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/54471/large/corn.jpg?1739933588"
+  },
+  {
+    "chainId": 1,
+    "address": "0xDDB3422497E61e13543BeA06989C0789117555c5",
+    "name": "COTI",
+    "symbol": "COTI",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/2962/thumb/Coti.png?1559653863"
+  },
+  {
+    "chainId": 1,
+    "address": "0x3D658390460295FB963f54dC0899cfb1c30776Df",
+    "name": "Circuits of Value",
+    "symbol": "COVAL",
+    "decimals": 8,
+    "logoURI": "https://assets.coingecko.com/coins/images/588/thumb/coval-logo.png?1599493950"
+  },
+  {
+    "chainId": 1,
+    "address": "0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB",
+    "name": "CoW Protocol",
+    "symbol": "COW",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/24384/large/CoW-token_logo.png?1719524382"
+  },
+  {
+    "chainId": 1,
+    "address": "0x66761Fa41377003622aEE3c7675Fc7b5c1C2FaC5",
+    "name": "Clearpool",
+    "symbol": "CPOOL",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/19252/large/photo_2022-08-31_12.45.02.jpeg?1696518697"
+  },
+  {
+    "chainId": 1,
+    "address": "0xD417144312DbF50465b1C641d016962017Ef6240",
+    "name": "Covalent",
+    "symbol": "CQT",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/14168/thumb/covalent-cqt.png?1624545218"
+  },
+  {
+    "chainId": 1,
+    "address": "0xA0b73E1Ff0B80914AB6fe0444E65848C4C34450b",
+    "name": "Cronos",
+    "symbol": "CRO",
+    "decimals": 8,
+    "logoURI": "https://assets.coingecko.com/coins/images/7310/thumb/oCw2s3GI_400x400.jpeg?1645172042"
+  },
+  {
+    "chainId": 1,
+    "address": "0x08389495D7456E1951ddF7c3a1314A4bfb646d8B",
+    "name": "Crypterium",
+    "symbol": "CRPT",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/1901/thumb/crypt.png?1547036205"
+  },
+  {
+    "name": "Curve DAO Token",
+    "address": "0xD533a949740bb3306d119CC777fa900bA034cd52",
+    "symbol": "CRV",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xD533a949740bb3306d119CC777fa900bA034cd52/logo.png"
+  },
+  {
+    "chainId": 1,
+    "address": "0xa3EE21C306A700E682AbCdfe9BaA6A08F3820419",
+    "name": "Creditcoin",
+    "symbol": "CTC",
+    "decimals": 18,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/10569/large/Creditcoin_Symbol_dark56.png?1737796066"
+  },
+  {
+    "chainId": 1,
+    "address": "0x491604c0FDF08347Dd1fa4Ee062a822A5DD06B5D",
+    "name": "Cartesi",
+    "symbol": "CTSI",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/11038/thumb/cartesi.png?1592288021"
+  },
+  {
+    "chainId": 1,
+    "address": "0x321C2fE4446C7c963dc41Dd58879AF648838f98D",
+    "name": "Cryptex Finance",
+    "symbol": "CTX",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/14932/thumb/glossy_icon_-_C200px.png?1619073171"
+  },
+  {
+    "chainId": 1,
+    "address": "0xDf801468a808a32656D2eD2D2d80B72A129739f4",
+    "name": "Somnium Space CUBEs",
+    "symbol": "CUBE",
+    "decimals": 8,
+    "logoURI": "https://assets.coingecko.com/coins/images/10687/thumb/CUBE_icon.png?1617026861"
+  },
+  {
+    "chainId": 1,
+    "address": "0x41e5560054824eA6B0732E656E3Ad64E20e94E45",
+    "name": "Civic",
+    "symbol": "CVC",
+    "decimals": 8,
+    "logoURI": "https://assets.coingecko.com/coins/images/788/thumb/civic.png?1547034556"
+  },
+  {
+    "chainId": 1,
+    "address": "0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B",
+    "name": "Convex Finance",
+    "symbol": "CVX",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/15585/thumb/convex.png?1621256328"
+  },
+  {
+    "chainId": 1,
+    "address": "0x7ABc8A5768E6bE61A6c693a6e4EAcb5B60602C4D",
+    "name": "Covalent X Token",
+    "symbol": "CXT",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/39177/large/CXT_Ticker.png?1720829918"
+  },
+  {
+    "name": "Dai Stablecoin",
+    "address": "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+    "symbol": "DAI",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6B175474E89094C44Da98b954EedeAC495271d0F/logo.png"
+  },
+  {
+    "chainId": 1,
+    "address": "0x081131434f93063751813C619Ecca9C4dC7862a3",
+    "name": "Mines of Dalarnia",
+    "symbol": "DAR",
+    "decimals": 6,
+    "logoURI": "https://assets.coingecko.com/coins/images/19837/thumb/dar.png?1636014223"
+  },
+  {
+    "chainId": 1,
+    "address": "0x3A880652F47bFaa771908C07Dd8673A787dAEd3A",
+    "name": "DerivaDAO",
+    "symbol": "DDX",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/13453/thumb/ddx_logo.png?1608741641"
+  },
+  {
+    "chainId": 1,
+    "address": "0x3597bfD533a99c9aa083587B074434E61Eb0A258",
+    "name": "Dent",
+    "symbol": "DENT",
+    "decimals": 8,
+    "logoURI": "https://assets.coingecko.com/coins/images/1152/thumb/gLCEA2G.png?1604543239"
+  },
+  {
+    "chainId": 1,
+    "address": "0xfB7B4564402E5500dB5bB6d63Ae671302777C75a",
+    "name": "DexTools",
+    "symbol": "DEXT",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/11603/thumb/dext.png?1605790188"
+  },
+  {
+    "chainId": 1,
+    "address": "0x84cA8bc7997272c7CfB4D0Cd3D55cd942B3c9419",
+    "name": "DIA",
+    "symbol": "DIA",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/11955/thumb/image.png?1646041751"
+  },
+  {
+    "chainId": 1,
+    "address": "0x0AbdAce70D3790235af448C88547603b945604ea",
+    "name": "district0x",
+    "symbol": "DNT",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/849/thumb/district0x.png?1547223762"
+  },
+  {
+    "chainId": 1,
+    "address": "0x0F81001eF0A83ecCE5ccebf63EB302c70a39a654",
+    "name": "Dolomite",
+    "symbol": "DOLO",
+    "decimals": 18,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/54710/large/DOLO-small.png?1745398535"
+  },
+  {
+    "chainId": 1,
+    "address": "0x2aeAbde1aB736c59E9A19BeD67681869eEF39526",
+    "name": "DOVU",
+    "symbol": "DOVU",
+    "decimals": 8,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/31930/large/Dovu_Icon_Black_%281%29.png?1696530738"
+  },
+  {
+    "chainId": 1,
+    "address": "0x1494CA1F11D487c2bBe4543E90080AeBa4BA3C2b",
+    "name": "DeFi Pulse Index",
+    "symbol": "DPI",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/12465/thumb/defi_pulse_index_set.png?1600051053"
+  },
+  {
+    "chainId": 1,
+    "address": "0x3Ab6Ed69Ef663bd986Ee59205CCaD8A20F98b4c2",
+    "name": "Drep",
+    "symbol": "DREP",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/14578/thumb/KotgsCgS_400x400.jpg?1617094445"
+  },
+  {
+    "chainId": 1,
+    "address": "0xB1D1eae60EEA9525032a6DCb4c1CE336a1dE71BE",
+    "name": "Derive",
+    "symbol": "DRV",
+    "decimals": 18,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/52889/large/Token_Logo.png?1734601695"
+  },
+  {
+    "chainId": 1,
+    "address": "0x92D6C1e31e14520e676a687F0a93788B716BEff5",
+    "name": "dYdX",
+    "symbol": "DYDX",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/17500/thumb/hjnIm9bV.jpg?1628009360"
+  },
+  {
+    "chainId": 1,
+    "address": "0x961C8c0B1aaD0c0b10a51FeF6a867E3091BCef17",
+    "name": "DeFi Yield Protocol",
+    "symbol": "DYP",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/13480/thumb/DYP_Logo_Symbol-8.png?1655809066"
+  },
+  {
+    "chainId": 1,
+    "address": "0xB0076DE78Dc50581770BBa1D211dDc0aD4F2a241",
+    "name": "EDGEX",
+    "symbol": "EDGEX",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/markets/images/11726/large/Logo_White_-_Black_BG.png?1727920571"
+  },
+  {
+    "chainId": 1,
+    "address": "0xec53bF9167f50cDEB3Ae105f56099aaaB9061F83",
+    "name": "EigenLayer",
+    "symbol": "EIGEN",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/37441/large/eigen.jpg?1728023974"
+  },
+  {
+    "chainId": 1,
+    "address": "0xe6fd75ff38Adca4B97FBCD938c86b98772431867",
+    "name": "Elastos",
+    "symbol": "ELA",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/2780/thumb/Elastos.png?1597048112"
+  },
+  {
+    "chainId": 1,
+    "address": "0x761D38e5ddf6ccf6Cf7c55759d5210750B5D60F3",
+    "name": "Dogelon Mars",
+    "symbol": "ELON",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/14962/thumb/6GxcPRo3_400x400.jpg?1619157413"
+  },
+  {
+    "chainId": 1,
+    "address": "0x57e114B691Db790C35207b2e685D4A43181e6061",
+    "name": "Ethena",
+    "symbol": "ENA",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/36530/standard/ethena.png"
+  },
+  {
+    "chainId": 1,
+    "address": "0xF629cBd94d3791C9250152BD8dfBDF380E2a3B9c",
+    "name": "Enjin Coin",
+    "symbol": "ENJ",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/1102/thumb/enjin-coin-logo.png?1547035078"
+  },
+  {
+    "chainId": 1,
+    "address": "0xC18360217D8F7Ab5e7c516566761Ea12Ce7F9D72",
+    "name": "Ethereum Name Service",
+    "symbol": "ENS",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/19785/thumb/acatxTm8_400x400.jpg?1635850140"
+  },
+  {
+    "chainId": 1,
+    "address": "0xE2AD0BF751834f2fbdC62A41014f84d67cA1de2A",
+    "name": "Caldera",
+    "symbol": "ERA",
+    "decimals": 18,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/54475/large/Token_Logo.png?1749676251"
+  },
+  {
+    "chainId": 1,
+    "address": "0xBBc2AE13b23d715c30720F079fcd9B4a74093505",
+    "name": "Ethernity Chain",
+    "symbol": "ERN",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/14238/thumb/LOGO_HIGH_QUALITY.png?1647831402"
+  },
+  {
+    "chainId": 1,
+    "address": "0x6055Dc6Ff1077eebe5e6D2BA1a1f53d7Ef8430dE",
+    "name": "Eclipse",
+    "symbol": "ES",
+    "decimals": 6,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/54958/large/image_%2832%29.png?1742979704"
+  },
+  {
+    "chainId": 1,
+    "address": "0x031De51F3E8016514Bd0963d0B2AB825A591Db9A",
+    "name": "Espresso",
+    "symbol": "ESP",
+    "decimals": 18,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/67626/large/espresso.jpg?1753324525"
+  },
+  {
+    "chainId": 1,
+    "address": "0xFe0c30065B384F05761f15d0CC899D4F9F9Cc0eB",
+    "name": "Ether.fi",
+    "symbol": "ETHFI",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/35958/standard/etherfi.jpeg"
+  },
+  {
+    "chainId": 1,
+    "address": "0xd9Fcd98c322942075A5C3860693e9f4f03AAE07b",
+    "name": "Euler",
+    "symbol": "EUL",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/26149/thumb/YCvKDfl8_400x400.jpeg?1656041509"
+  },
+  {
+    "chainId": 1,
+    "address": "0x1aBaEA1f7C830bD89Acc67eC4af516284b1bC33c",
+    "name": "Euro Coin",
+    "symbol": "EURC",
+    "decimals": 6,
+    "logoURI": "https://assets.coingecko.com/coins/images/26045/thumb/euro-coin.png?1655394420"
+  },
+  {
+    "chainId": 1,
+    "address": "0x888883b5F5D21fb10Dfeb70e8f9722B9FB0E5E51",
+    "name": "Schuman EUR P",
+    "symbol": "EUROP",
+    "decimals": 6,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/52132/large/europ-symbol-rgb.jpg?1732634862"
+  },
+  {
+    "chainId": 1,
+    "address": "0x8dF723295214Ea6f21026eeEb4382d475f146F9f",
+    "name": "Quantoz EURQ",
+    "symbol": "EURQ",
+    "decimals": 6,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/51853/large/EURQ_1000px_Color.png?1732071269"
+  },
+  {
+    "chainId": 1,
+    "address": "0x50753CfAf86c094925Bf976f218D043f8791e408",
+    "name": "StablR Euro",
+    "symbol": "EURR",
+    "decimals": 6,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/53720/large/stablreuro-logo.png?1737125898"
+  },
+  {
+    "chainId": 1,
+    "address": "0xa0246c9032bC3A600820415aE600c6388619A14D",
+    "name": "Harvest Finance",
+    "symbol": "FARM",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/12304/thumb/Harvest.png?1613016180"
+  },
+  {
+    "chainId": 1,
+    "address": "0xaea46A60368A7bD060eec7DF8CBa43b7EF41Ad85",
+    "name": "Fetch ai",
+    "symbol": "FET",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/5681/thumb/Fetch.jpg?1572098136"
+  },
+  {
+    "chainId": 1,
+    "address": "0x7C135549504245B5eAe64fc0E99Fa5ebabb8e35D",
+    "name": "Fidelity Digital Dollar",
+    "symbol": "FIDD",
+    "decimals": 18,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/102171776/large/FIDD-Green_%28792px%29.png?1769612802"
+  },
+  {
+    "chainId": 1,
+    "address": "0xef3A930e1FfFFAcd2fc13434aC81bD278B0ecC8d",
+    "name": "Stafi",
+    "symbol": "FIS",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/12423/thumb/stafi_logo.jpg?1599730991"
+  },
+  {
+    "chainId": 1,
+    "address": "0xcf0C122c6b73ff809C693DB761e7BaeBe62b6a2E",
+    "name": "FLOKI",
+    "symbol": "FLOKI",
+    "decimals": 9,
+    "logoURI": "https://assets.coingecko.com/coins/images/16746/standard/PNG_image.png?1696516318"
+  },
+  {
+    "chainId": 1,
+    "address": "0x720CD16b011b987Da3518fbf38c3071d4F0D1495",
+    "name": "Flux",
+    "symbol": "FLUX",
+    "decimals": 18,
+    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x720CD16b011b987Da3518fbf38c3071d4F0D1495/logo.png"
+  },
+  {
+    "chainId": 1,
+    "address": "0x41545f8b9472D758bB669ed8EaEEEcD7a9C4Ec29",
+    "name": "Forta",
+    "symbol": "FORT",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/25060/thumb/Forta_lgo_%281%29.png?1655353696"
+  },
+  {
+    "chainId": 1,
+    "address": "0x77FbA179C79De5B7653F68b5039Af940AdA60ce0",
+    "name": "Ampleforth Governance Token",
+    "symbol": "FORTH",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/14917/thumb/photo_2021-04-22_00.00.03.jpeg?1619020835"
+  },
+  {
+    "chainId": 1,
+    "address": "0xc770EEfAd204B5180dF6a14Ee197D99d808ee52d",
+    "name": "ShapeShift FOX Token",
+    "symbol": "FOX",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/9988/thumb/FOX.png?1574330622"
+  },
+  {
+    "chainId": 1,
+    "address": "0x853d955aCEf822Db058eb8505911ED77F175b99e",
+    "name": "Frax",
+    "symbol": "FRAX",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/13422/thumb/frax_logo.png?1608476506"
+  },
+  {
+    "chainId": 1,
+    "address": "0x4E15361FD6b4BB609Fa63C81A2be19d873717870",
+    "name": "Fantom",
+    "symbol": "FTM",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/4001/thumb/Fantom.png?1558015016"
+  },
+  {
+    "chainId": 1,
+    "address": "0x8c15Ef5b4B21951d50E53E4fbdA8298FFAD25057",
+    "name": "Function X",
+    "symbol": "FX",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/8186/thumb/47271330_590071468072434_707260356350705664_n.jpg?1556096683"
+  },
+  {
+    "chainId": 1,
+    "address": "0x3432B6A60D23Ca0dFCa7761B7ab56459D9C964D0",
+    "name": "Frax Share",
+    "symbol": "FXS",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/13423/thumb/frax_share.png?1608478989"
+  },
+  {
+    "chainId": 1,
+    "address": "0x9C7BEBa8F6eF6643aBd725e45a4E8387eF260649",
+    "name": "Gravity",
+    "symbol": "G",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/39200/large/gravity.jpg?1721020647"
+  },
+  {
+    "chainId": 1,
+    "address": "0x5fAa989Af96Af85384b8a938c2EdE4A7378D9875",
+    "name": "Galxe",
+    "symbol": "GAL",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/24530/thumb/GAL-Token-Icon.png?1651483533"
+  },
+  {
+    "chainId": 1,
+    "address": "0xd1d2Eb1B1e90B638588728b4130137D262C87cae",
+    "name": "GALA",
+    "symbol": "GALA",
+    "decimals": 8,
+    "logoURI": "https://assets.coingecko.com/coins/images/12493/standard/GALA-COINGECKO.png?1696512310"
+  },
+  {
+    "chainId": 1,
+    "address": "0xdab396cCF3d84Cf2D07C4454e10C8A6F5b008D2b",
+    "name": "Goldfinch",
+    "symbol": "GFI",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/19081/thumb/GOLDFINCH.png?1634369662"
+  },
+  {
+    "chainId": 1,
+    "address": "0x3F382DbD960E3a9bbCeaE22651E88158d2791550",
+    "name": "Aavegotchi",
+    "symbol": "GHST",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/12467/thumb/ghst_200.png?1600750321"
+  },
+  {
+    "chainId": 1,
+    "address": "0x7DD9c5Cba05E151C895FDe1CF355C9A1D5DA6429",
+    "name": "Golem",
+    "symbol": "GLM",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/542/thumb/Golem_Submark_Positive_RGB.png?1606392013"
+  },
+  {
+    "name": "Gnosis Token",
+    "address": "0x6810e776880C02933D47DB1b9fc05908e5386b96",
+    "symbol": "GNO",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x6810e776880C02933D47DB1b9fc05908e5386b96/logo.png"
+  },
+  {
+    "chainId": 1,
+    "address": "0xccC8cb5229B0ac8069C51fd58367Fd1e622aFD97",
+    "name": "Gods Unchained",
+    "symbol": "GODS",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/17139/thumb/10631.png?1635718182"
+  },
+  {
+    "chainId": 1,
+    "address": "0xc944E90C64B2c07662A292be6244BDf05Cda44a7",
+    "name": "The Graph",
+    "symbol": "GRT",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/13397/thumb/Graph_Token.png?1608145566"
+  },
+  {
+    "chainId": 1,
+    "address": "0xDe30da39c46104798bB5aA3fe8B9e0e1F348163F",
+    "name": "Gitcoin",
+    "symbol": "GTC",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/15810/thumb/gitcoin.png?1621992929"
+  },
+  {
+    "chainId": 1,
+    "address": "0x056Fd409E1d7A124BD7017459dFEa2F387b6d5Cd",
+    "name": "Gemini Dollar",
+    "symbol": "GUSD",
+    "decimals": 2,
+    "logoURI": "https://assets.coingecko.com/coins/images/5992/thumb/gemini-dollar-gusd.png?1536745278"
+  },
+  {
+    "chainId": 1,
+    "address": "0x2798b1cC5A993085E8A9D46e80499F1B63f42204",
+    "name": "ETHGas",
+    "symbol": "GWEI",
+    "decimals": 18,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/71375/large/ethgas_token_200.png?1769055039"
+  },
+  {
+    "chainId": 1,
+    "address": "0xC08512927D12348F6620a698105e1BAac6EcD911",
+    "name": "GYEN",
+    "symbol": "GYEN",
+    "decimals": 6,
+    "logoURI": "https://assets.coingecko.com/coins/images/14191/thumb/icon_gyen_200_200.png?1614843343"
+  },
+  {
+    "chainId": 1,
+    "address": "0xb3999F658C0391d94A37f7FF328F3feC942BcADC",
+    "name": "Hashflow",
+    "symbol": "HFT",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/26136/large/hashflow-icon-cmc.png"
+  },
+  {
+    "chainId": 1,
+    "address": "0x71Ab77b7dbB4fa7e017BC15090b2163221420282",
+    "name": "Highstreet",
+    "symbol": "HIGH",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/18973/thumb/logosq200200Coingecko.png?1634090470"
+  },
+  {
+    "chainId": 1,
+    "name": "HOPR",
+    "symbol": "HOPR",
+    "logoURI": "https://assets.coingecko.com/coins/images/14061/thumb/Shared_HOPR_logo_512px.png?1614073468",
+    "address": "0xF5581dFeFD8Fb0e4aeC526bE659CFaB1f8c781dA",
+    "decimals": 18
+  },
+  {
+    "chainId": 1,
+    "address": "0xB705268213D593B8FD88d3FDEFF93AFF5CbDcfAE",
+    "name": "IDEX",
+    "symbol": "IDEX",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/2565/thumb/logomark-purple-286x286.png?1638362736"
+  },
+  {
+    "chainId": 1,
+    "address": "0x767FE9EDC9E0dF98E07454847909b5E959D7ca0E",
+    "name": "Illuvium",
+    "symbol": "ILV",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/14468/large/ILV.JPG"
+  },
+  {
+    "chainId": 1,
+    "address": "0xb48c6B24f36307c7A1f2a9281E978a9ef2902BA5",
+    "name": "ImmuneFi",
+    "symbol": "IMU",
+    "decimals": 18,
+    "logoURI": "https://s2.coinmarketcap.com/static/img/coins/64x64/39429.png"
+  },
+  {
+    "chainId": 1,
+    "address": "0xF57e7e7C23978C3cAEC3C3548E3D615c346e79fF",
+    "name": "Immutable X",
+    "symbol": "IMX",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/17233/thumb/imx.png?1636691817"
+  },
+  {
+    "chainId": 1,
+    "name": "Index Cooperative",
+    "symbol": "INDEX",
+    "logoURI": "https://assets.coingecko.com/coins/images/12729/thumb/index.png?1634894321",
+    "address": "0x0954906da0Bf32d5479e25f46056d22f08464cab",
+    "decimals": 18
+  },
+  {
+    "chainId": 1,
+    "address": "0xe28b3B32B6c345A34Ff64674606124Dd5Aceca30",
+    "name": "Injective",
+    "symbol": "INJ",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/12882/thumb/Secondary_Symbol.png?1628233237"
+  },
+  {
+    "chainId": 1,
+    "address": "0x41D5D79431A913C4aE7d69a668ecdfE5fF9DFB68",
+    "name": "Inverse Finance",
+    "symbol": "INV",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/14205/thumb/inverse_finance.jpg?1614921871"
+  },
+  {
+    "chainId": 1,
+    "address": "0xdeF1b2D939EdC0E4d35806c59b3166F790175afe",
+    "name": "Infinex",
+    "symbol": "INX",
+    "decimals": 18,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/70868/large/infinex.png?1764322875"
+  },
+  {
+    "chainId": 1,
+    "address": "0x6fB3e0A217407EFFf7Ca062D46c26E5d60a14d69",
+    "name": "IoTeX",
+    "symbol": "IOTX",
+    "decimals": 18,
+    "logoURI": "https://s2.coinmarketcap.com/static/img/coins/64x64/2777.png"
+  },
+  {
+    "chainId": 1,
+    "address": "0x50f41F589aFACa2EF41FDF590FE7b90cD26DEe64",
+    "name": "Irys",
+    "symbol": "IRYS",
+    "decimals": 18,
+    "logoURI": "https://s2.coinmarketcap.com/static/img/coins/64x64/38978.png"
+  },
+  {
+    "chainId": 1,
+    "name": "Geojam",
+    "symbol": "JAM",
+    "logoURI": "https://assets.coingecko.com/coins/images/24648/thumb/ey40AzBN_400x400.jpg?1648507272",
+    "address": "0x23894DC9da6c94ECb439911cAF7d337746575A72",
+    "decimals": 18
+  },
+  {
+    "chainId": 1,
+    "address": "0x7420B4b9a0110cdC71fB720908340C03F9Bc03EC",
+    "name": "JasmyCoin",
+    "symbol": "JASMY",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/13876/thumb/JASMY200x200.jpg?1612473259"
+  },
+  {
+    "chainId": 1,
+    "name": "Jupiter",
+    "symbol": "JUP",
+    "logoURI": "https://assets.coingecko.com/coins/images/10351/thumb/logo512.png?1632480932",
+    "address": "0x4B1E80cAC91e2216EEb63e29B957eB91Ae9C2Be8",
+    "decimals": 18
+  },
+  {
+    "chainId": 1,
+    "address": "0xfb072b42907dA2Bf7A8E8cB5dCAa790D45Fd81a8",
+    "name": "Sidekick",
+    "symbol": "K",
+    "decimals": 18,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/67966/large/kick.jpg?1754450296"
+  },
+  {
+    "chainId": 1,
+    "address": "0x85Eee30c52B0b379b046Fb0F85F4f3Dc3009aFEC",
+    "name": "Keep Network",
+    "symbol": "KEEP",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/3373/thumb/IuNzUb5b_400x400.jpg?1589526336"
+  },
+  {
+    "chainId": 1,
+    "address": "0x3f80B1c54Ae920Be41a77f8B902259D48cf24cCf",
+    "name": "KernelDAO",
+    "symbol": "KERNEL",
+    "decimals": 18,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/54326/large/Kernel_token_logo_2x.png?1739827205"
+  },
+  {
+    "chainId": 1,
+    "name": "SelfKey",
+    "symbol": "KEY",
+    "logoURI": "https://assets.coingecko.com/coins/images/2034/thumb/selfkey.png?1548608934",
+    "address": "0x4CC19356f2D37338b9802aa8E8fc58B0373296E7",
+    "decimals": 18
+  },
+  {
+    "chainId": 1,
+    "address": "0x904567252D8F48555b7447c67dCA23F0372E16be",
+    "name": "Kite",
+    "symbol": "KITE",
+    "decimals": 18,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/70426/large/KITE-ICON.png?1762328605"
+  },
+  {
+    "name": "Kyber Network Crystal",
+    "address": "0xdd974D5C2e2928deA5F71b9825b8b646686BD200",
+    "symbol": "KNC",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdd974D5C2e2928deA5F71b9825b8b646686BD200/logo.png"
+  },
+  {
+    "chainId": 1,
+    "address": "0x1cEB5cB57C4D4E2b2433641b95Dd330A33185A44",
+    "name": "Keep3rV1",
+    "symbol": "KP3R",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/12966/thumb/kp3r_logo.jpg?1607057458"
+  },
+  {
+    "chainId": 1,
+    "address": "0x464eBE77c293E473B48cFe96dDCf88fcF7bFDAC0",
+    "name": "KRYLL",
+    "symbol": "KRL",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/2807/thumb/krl.png?1547036979"
   },
   {
     "chainId": 1,
@@ -2195,54 +1452,6 @@
   },
   {
     "chainId": 1,
-    "address": "0x7613C48E0cd50E42dD9Bf0f6c235063145f6f8DC",
-    "name": "Pirate Nation",
-    "symbol": "PIRATE",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/38524/standard/_Pirate_Transparent_200x200.png"
-  },
-  {
-    "chainId": 1,
-    "address": "0xcf0C122c6b73ff809C693DB761e7BaeBe62b6a2E",
-    "name": "FLOKI",
-    "symbol": "FLOKI",
-    "decimals": 9,
-    "logoURI": "https://assets.coingecko.com/coins/images/16746/standard/PNG_image.png?1696516318"
-  },
-  {
-    "chainId": 1,
-    "address": "0x3B50805453023a91a8bf641e279401a0b23FA6F9",
-    "name": "Renzo",
-    "symbol": "REZ",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/37327/standard/renzo_200x200.png?1714025012"
-  },
-  {
-    "chainId": 1,
-    "address": "0x3E5A19c91266aD8cE2477B91585d1856B84062dF",
-    "name": "Ancient8",
-    "symbol": "A8",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/39170/standard/A8_Token-04_200x200.png?1720798300"
-  },
-  {
-    "chainId": 1,
-    "address": "0xd0a6053f087E87a25dC60701ba6E663b1a548E85",
-    "name": "BLOCKLORDS",
-    "symbol": "LRDS",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/34775/standard/LRDS_PNG.png"
-  },
-  {
-    "chainId": 1,
-    "address": "0x30D20208d987713f46DFD34EF128Bb16C404D10f",
-    "name": "Stader",
-    "symbol": "SD",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/20658/standard/SD_Token_Logo.png"
-  },
-  {
-    "chainId": 1,
     "address": "0x88909D489678dD17aA6D9609F89B0419Bf78FD9a",
     "name": "Layer3",
     "symbol": "L3",
@@ -2250,60 +1459,44 @@
     "logoURI": "https://assets.coingecko.com/coins/images/37768/large/Square.png"
   },
   {
-    "chainId": 1,
-    "address": "0x7ABc8A5768E6bE61A6c693a6e4EAcb5B60602C4D",
-    "name": "Covalent X Token",
-    "symbol": "CXT",
+    "name": "Lagrange",
+    "address": "0x0fc2a55d5BD13033f1ee0cdd11f60F7eFe66f467",
+    "symbol": "LA",
     "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/39177/large/CXT_Ticker.png?1720829918"
+    "chainId": 1,
+    "logoURI": "https://s2.coinmarketcap.com/static/img/coins/64x64/36510.png"
   },
   {
     "chainId": 1,
-    "address": "0x9C7BEBa8F6eF6643aBd725e45a4E8387eF260649",
-    "name": "Gravity",
-    "symbol": "G",
+    "address": "0x037A54AaB062628C9Bbae1FDB1583c195585fe41",
+    "name": "LCX",
+    "symbol": "LCX",
     "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/39200/large/gravity.jpg?1721020647"
+    "logoURI": "https://assets.coingecko.com/coins/images/9985/thumb/zRPSu_0o_400x400.jpg?1574327008"
   },
   {
     "chainId": 1,
-    "address": "0xA35923162C49cF95e6BF26623385eb431ad920D3",
-    "name": "Turbo",
-    "symbol": "TURBO",
+    "address": "0x5A98FcBEA516Cf06857215779Fd812CA3beF1B32",
+    "name": "Lido DAO",
+    "symbol": "LDO",
     "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/30117/large/TurboMark-QL_200.png?1708079597"
+    "logoURI": "https://assets.coingecko.com/coins/images/13573/thumb/Lido_DAO.png?1609873644"
   },
   {
     "chainId": 1,
-    "address": "0x66761Fa41377003622aEE3c7675Fc7b5c1C2FaC5",
-    "name": "Clearpool",
-    "symbol": "CPOOL",
+    "address": "0x1789e0043623282D5DCc7F213d703C6D8BAfBB04",
+    "name": "Linea",
+    "symbol": "LINEA",
     "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/19252/large/photo_2022-08-31_12.45.02.jpeg?1696518697"
+    "logoURI": "https://coin-images.coingecko.com/coins/images/68507/large/linea-logo.jpeg?1756025484"
   },
   {
-    "chainId": 1,
-    "address": "0x44108f0223A3C3028F5Fe7AEC7f9bb2E66beF82F",
-    "name": "Across Protocol Token",
-    "symbol": "ACX",
+    "name": "ChainLink Token",
+    "address": "0x514910771AF9Ca656af840dff83E8264EcF986CA",
+    "symbol": "LINK",
     "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/28161/large/across-200x200.png?1696527165"
-  },
-  {
     "chainId": 1,
-    "address": "0xaaeE1A9723aaDB7afA2810263653A34bA2C21C7a",
-    "name": "Mog Coin",
-    "symbol": "MOG",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/31059/large/MOG_LOGO_200x200.png"
-  },
-  {
-    "chainId": 1,
-    "address": "0xb131f4A55907B10d1F0A50d8ab8FA09EC342cd74",
-    "name": "Memecoin",
-    "symbol": "MEME",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/32528/large/memecoin_(2).png"
+    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x514910771AF9Ca656af840dff83E8264EcF986CA/logo.png"
   },
   {
     "chainId": 1,
@@ -2315,235 +1508,59 @@
   },
   {
     "chainId": 1,
-    "address": "0x455e53CBB86018Ac2B8092FdCd39d8444aFFC3F6",
-    "name": "Polygon Ecosystem Token",
-    "symbol": "POL",
+    "address": "0x232CE3bd40fCd6f80f3d55A522d03f25Df784Ee2",
+    "name": "Lighter",
+    "symbol": "LIT",
     "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/32440/large/polygon.png?1698233684"
+    "logoURI": "https://coin-images.coingecko.com/coins/images/71121/large/lighter.png?1765888098"
   },
   {
     "chainId": 1,
-    "name": "Coinbase Wrapped BTC",
-    "address": "0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf",
-    "symbol": "cbBTC",
-    "decimals": 8,
-    "logoURI": "https://assets.coingecko.com/coins/images/40143/standard/cbbtc.webp"
+    "name": "League of Kingdoms",
+    "symbol": "LOKA",
+    "logoURI": "https://assets.coingecko.com/coins/images/22572/thumb/loka_64pix.png?1642643271",
+    "address": "0x61E90A50137E1F645c9eF4a0d3A4f01477738406",
+    "decimals": 18
   },
   {
-    "chainId": 1,
-    "address": "0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB",
-    "name": "CoW Protocol",
-    "symbol": "COW",
+    "name": "Loom Network",
+    "address": "0xA4e8C3Ec456107eA67d3075bF9e3DF3A75823DB0",
+    "symbol": "LOOM",
     "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/24384/large/CoW-token_logo.png?1719524382"
+    "chainId": 1,
+    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA4e8C3Ec456107eA67d3075bF9e3DF3A75823DB0/logo.png"
   },
   {
     "chainId": 1,
-    "address": "0xdC035D45d973E3EC169d2276DDab16f1e407384F",
-    "name": "USDS Stablecoin",
-    "symbol": "USDS",
+    "address": "0x58b6A8A3302369DAEc383334672404Ee733aB239",
+    "name": "Livepeer",
+    "symbol": "LPT",
     "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/39926/large/usds.webp?1726666683"
+    "logoURI": "https://assets.coingecko.com/coins/images/7137/thumb/logo-circle-green.png?1619593365"
   },
   {
     "chainId": 1,
-    "address": "0x56072C95FAA701256059aa122697B133aDEd9279",
-    "name": "SKY Governance Token",
-    "symbol": "SKY",
+    "address": "0x6DEA81C8171D0bA574754EF6F8b412F2Ed88c54D",
+    "name": "Liquity",
+    "symbol": "LQTY",
     "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/39925/large/sky.jpg?1724827980"
+    "logoURI": "https://assets.coingecko.com/coins/images/14665/thumb/200-lqty-icon.png?1617631180"
   },
   {
-    "chainId": 1,
-    "address": "0xec53bF9167f50cDEB3Ae105f56099aaaB9061F83",
-    "name": "EigenLayer",
-    "symbol": "EIGEN",
+    "name": "LoopringCoin V2",
+    "address": "0xBBbbCA6A901c926F240b89EacB641d8Aec7AEafD",
+    "symbol": "LRC",
     "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/37441/large/eigen.jpg?1728023974"
+    "chainId": 1,
+    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xBBbbCA6A901c926F240b89EacB641d8Aec7AEafD/logo.png"
   },
   {
     "chainId": 1,
-    "address": "0x4d1C297d39C5c1277964D0E3f8Aa901493664530",
-    "name": "Puffer Finance",
-    "symbol": "PUFFER",
+    "address": "0xd0a6053f087E87a25dC60701ba6E663b1a548E85",
+    "name": "BLOCKLORDS",
+    "symbol": "LRDS",
     "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/50630/large/puffer.jpg?1728545297"
-  },
-  {
-    "chainId": 1,
-    "address": "0xe343167631d89B6Ffc58B88d6b7fB0228795491D",
-    "name": "Global Dollar",
-    "symbol": "USDG",
-    "decimals": 6,
-    "logoURI": "https://assets.coingecko.com/coins/images/51281/large/GDN_USDG_Token_200x200.png"
-  },
-  {
-    "chainId": 1,
-    "address": "0x643C4E15d7d62Ad0aBeC4a9BD4b001aA3Ef52d66",
-    "name": "Syrup Token",
-    "symbol": "SYRUP",
-    "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/51232/standard/IMG_7420.png?1730831572"
-  },
-  {
-    "chainId": 1,
-    "address": "0xbe0Ed4138121EcFC5c0E56B40517da27E6c5226B",
-    "name": "Aethir Token",
-    "symbol": "ATH",
-    "decimals": 18,
-    "logoURI": "https://coin-images.coingecko.com/coins/images/36179/large/logogram_circle_dark_green_vb_green_(1).png?1718232706"
-  },
-  {
-    "chainId": 1,
-    "address": "0x594DaaD7D77592a2b97b725A7AD59D7E188b5bFa",
-    "name": "Apu Apustaja",
-    "symbol": "APU",
-    "decimals": 18,
-    "logoURI": "https://coin-images.coingecko.com/coins/images/35986/large/200x200.png?1710308147"
-  },
-  {
-    "chainId": 1,
-    "address": "0x58D97B57BB95320F9a05dC918Aef65434969c2B2",
-    "name": "Morpho Token",
-    "symbol": "MORPHO",
-    "decimals": 18,
-    "logoURI": "https://coin-images.coingecko.com/coins/images/29837/large/Morpho-token-icon.png?1726771230"
-  },
-  {
-    "chainId": 1,
-    "address": "0x8dF723295214Ea6f21026eeEb4382d475f146F9f",
-    "name": "Quantoz EURQ",
-    "symbol": "EURQ",
-    "decimals": 6,
-    "logoURI": "https://coin-images.coingecko.com/coins/images/51853/large/EURQ_1000px_Color.png?1732071269"
-  },
-  {
-    "chainId": 1,
-    "address": "0xc83e27f270cce0A3A3A29521173a83F402c1768b",
-    "name": "Quantoz USDQ",
-    "symbol": "USDQ",
-    "decimals": 6,
-    "logoURI": "https://coin-images.coingecko.com/coins/images/51852/large/USDQ_1000px_Color.png?1732071232"
-  },
-  {
-    "chainId": 1,
-    "address": "0x3073f7aAA4DB83f95e9FFf17424F71D4751a3073",
-    "name": "Movement",
-    "symbol": "MOVE",
-    "decimals": 8,
-    "logoURI": "https://s2.coinmarketcap.com/static/img/coins/64x64/32452.png"
-  },
-  {
-    "chainId": 1,
-    "address": "0x6033F7f88332B8db6ad452B7C6D5bB643990aE3f",
-    "name": "Lisk",
-    "symbol": "LSK",
-    "decimals": 18,
-    "logoURI": "https://coin-images.coingecko.com/coins/images/385/large/Lisk_logo.png?1722338450"
-  },
-  {
-    "chainId": 1,
-    "address": "0x812Ba41e071C7b7fA4EBcFB62dF5F45f6fA853Ee",
-    "name": "Neiro",
-    "symbol": "Neiro",
-    "decimals": 9,
-    "logoURI": "https://coin-images.coingecko.com/coins/images/39488/large/neiro.jpg?1731449567"
-  },
-  {
-    "chainId": 1,
-    "address": "0x0a6E7Ba5042B38349e437ec6Db6214AEC7B35676",
-    "name": "Swell",
-    "symbol": "SWELL",
-    "decimals": 18,
-    "logoURI": "https://coin-images.coingecko.com/coins/images/28777/large/swell1.png?1727899715"
-  },
-  {
-    "chainId": 1,
-    "address": "0xE0f63A424a4439cBE457D80E4f4b51aD25b2c56C",
-    "name": "SPX6900",
-    "symbol": "SPX",
-    "decimals": 8,
-    "logoURI": "https://coin-images.coingecko.com/coins/images/31401/large/sticker_(1).jpg?1702371083"
-  },
-  {
-    "chainId": 1,
-    "address": "0x320623b8E4fF03373931769A31Fc52A4E78B5d70",
-    "name": "Reserve Rights",
-    "symbol": "RSR",
-    "decimals": 18,
-    "logoURI": "https://coin-images.coingecko.com/coins/images/8365/large/RSR_Blue_Circle_1000.png?1721777856"
-  },
-  {
-    "chainId": 1,
-    "address": "0x8DE5B80a0C1B02Fe4976851D030B36122dbb8624",
-    "name": "VANRY",
-    "symbol": "VANRY",
-    "decimals": 18,
-    "logoURI": "https://coin-images.coingecko.com/coins/images/33466/large/apple-touch-icon.png?1701942541"
-  },
-  {
-    "chainId": 1,
-    "address": "0xC4441c2BE5d8fA8126822B9929CA0b81Ea0DE38E",
-    "name": "USUAL",
-    "symbol": "USUAL",
-    "decimals": 18,
-    "logoURI": "https://coin-images.coingecko.com/coins/images/51091/large/USUAL.jpg?1730035787"
-  },
-  {
-    "chainId": 1,
-    "address": "0x50753CfAf86c094925Bf976f218D043f8791e408",
-    "name": "StablR Euro",
-    "symbol": "EURR",
-    "decimals": 6,
-    "logoURI": "https://coin-images.coingecko.com/coins/images/53720/large/stablreuro-logo.png?1737125898"
-  },
-  {
-    "chainId": 1,
-    "address": "0x7B43E3875440B44613DC3bC08E7763e6Da63C8f8",
-    "name": "StablR USD",
-    "symbol": "USDR",
-    "decimals": 6,
-    "logoURI": "https://coin-images.coingecko.com/coins/images/53721/large/stablrusd-logo.png?1737126629"
-  },
-  {
-    "chainId": 1,
-    "address": "0x72e4f9F808C49A2a61dE9C5896298920Dc4EEEa9",
-    "name": "HarryPotterObamaSonic10Inu",
-    "symbol": "BITCOIN",
-    "decimals": 8,
-    "logoURI": "https://coin-images.coingecko.com/coins/images/30323/large/hpos10i_logo_casino_night-dexview.png?1696529224"
-  },
-  {
-    "chainId": 1,
-    "address": "0xcb1592591996765Ec0eFc1f92599A19767ee5ffA",
-    "name": "BIO",
-    "symbol": "BIO",
-    "decimals": 18,
-    "logoURI": "https://coin-images.coingecko.com/coins/images/53022/large/bio.jpg?1735011002"
-  },
-  {
-    "chainId": 1,
-    "address": "0x720CD16b011b987Da3518fbf38c3071d4F0D1495",
-    "name": "Flux",
-    "symbol": "FLUX",
-    "decimals": 18,
-    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x720CD16b011b987Da3518fbf38c3071d4F0D1495/logo.png"
-  },
-  {
-    "chainId": 1,
-    "address": "0xf983da3ca66964C02628189Ea8Ca99fa9E24f66c",
-    "name": "Wrapped Analog One Token",
-    "symbol": "WANLOG",
-    "decimals": 12,
-    "logoURI": "https://assets.kraken.com/marketing/web/icons-uni-webp/s_anlog.webp?i=kds"
-  },
-  {
-    "chainId": 1,
-    "address": "0xc43C6bfeDA065fE2c4c11765Bf838789bd0BB5dE",
-    "name": "Redstone",
-    "symbol": "RED",
-    "decimals": 18,
-    "logoURI": "https://coin-images.coingecko.com/coins/images/53640/large/RedStone_Logo_New_White.png?1740640919"
+    "logoURI": "https://assets.coingecko.com/coins/images/34775/standard/LRDS_PNG.png"
   },
   {
     "chainId": 1,
@@ -2555,67 +1572,138 @@
   },
   {
     "chainId": 1,
-    "address": "0x808507121B80c02388fAd14726482e061B8da827",
-    "name": "Pendle",
-    "symbol": "PENDLE",
+    "address": "0x6033F7f88332B8db6ad452B7C6D5bB643990aE3f",
+    "name": "Lisk",
+    "symbol": "LSK",
     "decimals": 18,
-    "logoURI": "https://coin-images.coingecko.com/coins/images/15069/large/Pendle_Logo_Normal-03.png?1696514728"
+    "logoURI": "https://coin-images.coingecko.com/coins/images/385/large/Lisk_logo.png?1722338450"
   },
   {
     "chainId": 1,
-    "address": "0x888883b5F5D21fb10Dfeb70e8f9722B9FB0E5E51",
-    "name": "Schuman EUR P",
-    "symbol": "EUROP",
-    "decimals": 6,
-    "logoURI": "https://coin-images.coingecko.com/coins/images/52132/large/europ-symbol-rgb.jpg?1732634862"
+    "name": "Liquity USD",
+    "symbol": "LUSD",
+    "logoURI": "https://assets.coingecko.com/coins/images/14666/thumb/Group_3.png?1617631327",
+    "address": "0x5f98805A4E8be255a32880FDeC7F6728C6568bA0",
+    "decimals": 18
   },
   {
     "chainId": 1,
-    "address": "0x4507cEf57C46789eF8d1a19EA45f4216bae2B528",
-    "name": "TokenFi",
-    "symbol": "TOKEN",
-    "decimals": 9,
-    "logoURI": "https://coin-images.coingecko.com/coins/images/32507/large/MAIN_TokenFi_logo_icon.png?1698918427"
-  },
-  {
-    "chainId": 1,
-    "address": "0xB1D1eae60EEA9525032a6DCb4c1CE336a1dE71BE",
-    "name": "Derive",
-    "symbol": "DRV",
+    "address": "0x0F5D2fB29fb7d3CFeE444a200298f468908cC942",
+    "name": "Decentraland",
+    "symbol": "MANA",
     "decimals": 18,
-    "logoURI": "https://coin-images.coingecko.com/coins/images/52889/large/Token_Logo.png?1734601695"
+    "logoURI": "https://assets.coingecko.com/coins/images/878/thumb/decentraland-mana.png?1550108745"
   },
   {
     "chainId": 1,
-    "address": "0x8292Bb45bf1Ee4d140127049757C2E0fF06317eD",
-    "name": "RLUSD",
-    "symbol": "RLUSD",
+    "address": "0x69af81e73A73B40adF4f3d4223Cd9b1ECE623074",
+    "name": "Mask Network",
+    "symbol": "MASK",
     "decimals": 18,
-    "logoURI": "https://coin-images.coingecko.com/coins/images/39651/large/RLUSD_200x200_(1).png?1727376633"
+    "logoURI": "https://assets.coingecko.com/coins/images/14051/thumb/Mask_Network.jpg?1614050316"
   },
   {
     "chainId": 1,
-    "address": "0xC3d21f79C3120A4fFda7A535f8005a7c297799bF",
-    "name": "Term Finance",
-    "symbol": "TERM",
-    "decimals": 18,
-    "logoURI": "https://coin-images.coingecko.com/coins/images/38142/large/terms.png?1716630303"
+    "name": "MATH",
+    "symbol": "MATH",
+    "logoURI": "https://assets.coingecko.com/coins/images/11335/thumb/2020-05-19-token-200.png?1589940590",
+    "address": "0x08d967bb0134F2d07f7cfb6E246680c53927DD30",
+    "decimals": 18
   },
   {
     "chainId": 1,
-    "address": "0x44f49ff0da2498bCb1D3Dc7C0f999578F67FD8C6",
-    "name": "Corn",
-    "symbol": "CORN",
+    "address": "0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0",
+    "name": "Polygon",
+    "symbol": "MATIC",
     "decimals": 18,
-    "logoURI": "https://coin-images.coingecko.com/coins/images/54471/large/corn.jpg?1739933588"
+    "logoURI": "https://assets.coingecko.com/coins/images/4713/thumb/matic-token-icon.png?1624446912",
+    "extensions": {
+      "bridgeInfo": {
+        "137": {
+          "tokenAddress": "0x0000000000000000000000000000000000001010"
+        }
+      }
+    }
   },
   {
     "chainId": 1,
-    "address": "0x3f80B1c54Ae920Be41a77f8B902259D48cf24cCf",
-    "name": "KernelDAO",
-    "symbol": "KERNEL",
+    "address": "0x949D48EcA67b17269629c7194F4b727d4Ef9E5d6",
+    "name": "Merit Circle",
+    "symbol": "MC",
     "decimals": 18,
-    "logoURI": "https://coin-images.coingecko.com/coins/images/54326/large/Kernel_token_logo_2x.png?1739827205"
+    "logoURI": "https://assets.coingecko.com/coins/images/19304/thumb/Db4XqML.png?1634972154"
+  },
+  {
+    "chainId": 1,
+    "address": "0xfC98e825A2264D890F9a1e68ed50E1526abCcacD",
+    "name": "Moss Carbon Credit",
+    "symbol": "MCO2",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/14414/thumb/ENtxnThA_400x400.jpg?1615948522"
+  },
+  {
+    "chainId": 1,
+    "address": "0x814e0908b12A99FeCf5BC101bB5d0b8B5cDf7d26",
+    "name": "Measurable Data Token",
+    "symbol": "MDT",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/2441/thumb/mdt_logo.png?1569813574"
+  },
+  {
+    "chainId": 1,
+    "address": "0xb131f4A55907B10d1F0A50d8ab8FA09EC342cd74",
+    "name": "Memecoin",
+    "symbol": "MEME",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/32528/large/memecoin_(2).png"
+  },
+  {
+    "chainId": 1,
+    "name": "Metis",
+    "symbol": "METIS",
+    "logoURI": "https://assets.coingecko.com/coins/images/15595/thumb/metis.jpeg?1660285312",
+    "address": "0x9E32b13ce7f2E80A01932B42553652E053D6ed8e",
+    "decimals": 18
+  },
+  {
+    "chainId": 1,
+    "address": "0x99D8a9C45b2ecA8864373A26D1459e3Dff1e17F3",
+    "name": "Magic Internet Money",
+    "symbol": "MIM",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/16786/thumb/mimlogopng.png?1624979612"
+  },
+  {
+    "chainId": 1,
+    "address": "0x09a3EcAFa817268f77BE1283176B946C4ff2E608",
+    "name": "Mirror Protocol",
+    "symbol": "MIR",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/13295/thumb/mirror_logo_transparent.png?1611554658"
+  },
+  {
+    "name": "Maker",
+    "address": "0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2",
+    "symbol": "MKR",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2/logo.png"
+  },
+  {
+    "chainId": 1,
+    "address": "0xec67005c4E498Ec7f55E092bd1d35cbC47C91892",
+    "name": "Melon",
+    "symbol": "MLN",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/605/thumb/melon.png?1547034295"
+  },
+  {
+    "name": "MMC Coin",
+    "address": "0x85374E57bFabCcA3613A84456687c8A0C0e0D8A4",
+    "symbol": "MMC",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://raw.githubusercontent.com/memecex/mmc-assets/main/logo_256x256.png"
   },
   {
     "chainId": 1,
@@ -2627,35 +1715,107 @@
   },
   {
     "chainId": 1,
-    "address": "0xE6Bfd33F52d82Ccb5b37E16D3dD81f9FFDAbB195",
-    "name": "Space and Time",
-    "symbol": "SXT",
+    "address": "0xaaeE1A9723aaDB7afA2810263653A34bA2C21C7a",
+    "name": "Mog Coin",
+    "symbol": "MOG",
     "decimals": 18,
-    "logoURI": "https://coin-images.coingecko.com/coins/images/55424/large/sxt-token_circle.jpg?1745935919"
-  },
-  {
-    "name": "Lagrange",
-    "address": "0x0fc2a55d5BD13033f1ee0cdd11f60F7eFe66f467",
-    "symbol": "LA",
-    "decimals": 18,
-    "chainId": 1,
-    "logoURI": "https://s2.coinmarketcap.com/static/img/coins/64x64/36510.png"
-  },
-  {
-    "name": "PancakeSwap",
-    "address": "0x152649eA73beAb28c5b49B26eb48f7EAD6d4c898",
-    "symbol": "CAKE",
-    "decimals": 18,
-    "chainId": 1,
-    "logoURI": "https://coin-images.coingecko.com/coins/images/12632/large/pancakeswap-cake-logo_%281%29.png?1696512440"
+    "logoURI": "https://assets.coingecko.com/coins/images/31059/large/MOG_LOGO_200x200.png"
   },
   {
     "chainId": 1,
-    "address": "0xc20059e0317DE91738d13af027DfC4a50781b066",
-    "name": "Spark",
-    "symbol": "SPK",
+    "name": "Monavale",
+    "symbol": "MONA",
+    "logoURI": "https://assets.coingecko.com/coins/images/13298/thumb/monavale_logo.jpg?1607232721",
+    "address": "0x275f5Ad03be0Fa221B4C6649B8AeE09a42D9412A",
+    "decimals": 18
+  },
+  {
+    "chainId": 1,
+    "address": "0x58D97B57BB95320F9a05dC918Aef65434969c2B2",
+    "name": "Morpho Token",
+    "symbol": "MORPHO",
     "decimals": 18,
-    "logoURI": "https://coin-images.coingecko.com/coins/images/38637/large/Spark-Logomark-RGB.png?1744878896"
+    "logoURI": "https://coin-images.coingecko.com/coins/images/29837/large/Morpho-token-icon.png?1726771230"
+  },
+  {
+    "chainId": 1,
+    "address": "0x3073f7aAA4DB83f95e9FFf17424F71D4751a3073",
+    "name": "Movement",
+    "symbol": "MOVE",
+    "decimals": 8,
+    "logoURI": "https://s2.coinmarketcap.com/static/img/coins/64x64/32452.png"
+  },
+  {
+    "chainId": 1,
+    "address": "0x33349B282065b0284d756F0577FB39c158F935e6",
+    "name": "Maple",
+    "symbol": "MPL",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/14097/thumb/photo_2021-05-03_14.20.41.jpeg?1620022863"
+  },
+  {
+    "chainId": 1,
+    "name": "Metal",
+    "symbol": "MTL",
+    "logoURI": "https://assets.coingecko.com/coins/images/763/thumb/Metal.png?1592195010",
+    "address": "0xF433089366899D83a9f26A773D59ec7eCF30355e",
+    "decimals": 8
+  },
+  {
+    "chainId": 1,
+    "address": "0x65Ef703f5594D2573eb71Aaf55BC0CB548492df4",
+    "name": "Multichain",
+    "symbol": "MULTI",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/22087/thumb/1_Wyot-SDGZuxbjdkaOeT2-A.png?1640764238"
+  },
+  {
+    "chainId": 1,
+    "address": "0xe2f2a5C287993345a840Db3B0845fbC70f5935a5",
+    "name": "mStable USD",
+    "symbol": "MUSD",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/11576/thumb/mStable_USD.png?1595591803"
+  },
+  {
+    "chainId": 1,
+    "name": "Muse DAO",
+    "symbol": "MUSE",
+    "logoURI": "https://assets.coingecko.com/coins/images/13230/thumb/muse_logo.png?1606460453",
+    "address": "0xB6Ca7399B4F9CA56FC27cBfF44F4d2e4Eef1fc81",
+    "decimals": 18
+  },
+  {
+    "chainId": 1,
+    "name": "GensoKishi Metaverse",
+    "symbol": "MV",
+    "logoURI": "https://s2.coinmarketcap.com/static/img/coins/64x64/17704.png",
+    "address": "0xAE788F80F2756A86aa2F410C651F2aF83639B95b",
+    "decimals": 18
+  },
+  {
+    "chainId": 1,
+    "name": "MXC",
+    "symbol": "MXC",
+    "logoURI": "https://assets.coingecko.com/coins/images/4604/thumb/mxc.png?1655534336",
+    "address": "0x5Ca381bBfb58f0092df149bD3D243b08B9a8386e",
+    "decimals": 18
+  },
+  {
+    "chainId": 1,
+    "address": "0x9E46A38F5DaaBe8683E10793b06749EEF7D733d1",
+    "name": "PolySwarm",
+    "symbol": "NCT",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/2843/thumb/ImcYCVfX_400x400.jpg?1628519767"
+  },
+  {
+    "chainId": 1,
+    "address": "0x812Ba41e071C7b7fA4EBcFB62dF5F45f6fA853Ee",
+    "name": "Neiro",
+    "symbol": "Neiro",
+    "decimals": 9,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/39488/large/neiro.jpg?1731449567"
   },
   {
     "chainId": 1,
@@ -2667,107 +1827,19 @@
   },
   {
     "chainId": 1,
-    "address": "0xE2AD0BF751834f2fbdC62A41014f84d67cA1de2A",
-    "name": "Caldera",
-    "symbol": "ERA",
+    "address": "0x5Cf04716BA20127F1E2297AdDCf4B5035000c9eb",
+    "name": "NKN",
+    "symbol": "NKN",
     "decimals": 18,
-    "logoURI": "https://coin-images.coingecko.com/coins/images/54475/large/Token_Logo.png?1749676251"
+    "logoURI": "https://assets.coingecko.com/coins/images/3375/thumb/nkn.png?1548329212"
   },
   {
-    "chainId": 1,
-    "address": "0xD33526068D116cE69F19A9ee46F0bd304F21A51f",
-    "name": "Rocket Pool Protocol",
-    "symbol": "RPL",
+    "name": "Numeraire",
+    "address": "0x1776e1F26f98b1A5dF9cD347953a26dd3Cb46671",
+    "symbol": "NMR",
     "decimals": 18,
-    "logoURI": "https://coin-images.coingecko.com/coins/images/2090/large/rocket_pool_%28RPL%29.png?1696503058"
-  },
-  {
     "chainId": 1,
-    "address": "0x77146784315Ba81904d654466968e3a7c196d1f3",
-    "name": "Treehouse Token",
-    "symbol": "TREE",
-    "decimals": 18,
-    "logoURI": "https://coin-images.coingecko.com/coins/images/67664/large/TREE_logo.png?1753601041"
-  },
-  {
-    "chainId": 1,
-    "address": "0x6BEF15D938d4E72056AC92Ea4bDD0D76B1C4ad29",
-    "name": "Succinct",
-    "symbol": "PROVE",
-    "decimals": 18,
-    "logoURI": "https://coin-images.coingecko.com/coins/images/67905/large/succinct-logo.png?1754228574"
-  },
-  {
-    "chainId": 1,
-    "address": "0xdA5e1988097297dCdc1f90D4dFE7909e847CBeF6",
-    "name": "World Liberty Financial",
-    "symbol": "WLFI",
-    "decimals": 18,
-    "logoURI": "https://coin-images.coingecko.com/coins/images/50767/large/wlfi.png?1756438915"
-  },
-  {
-    "chainId": 1,
-    "address": "0x8d0D000Ee44948FC98c9B98A4FA4921476f08B0d",
-    "name": "World Liberty Financial USD",
-    "symbol": "USD1",
-    "decimals": 18,
-    "logoURI": "https://coin-images.coingecko.com/coins/images/54977/large/USD1_1000x1000_transparent.png?1749297002"
-  },
-  {
-    "chainId": 1,
-    "address": "0xeF4461891DfB3AC8572cCf7C794664A8DD927945",
-    "name": "WalletConnect Token",
-    "symbol": "WCT",
-    "decimals": 18,
-    "logoURI": "https://coin-images.coingecko.com/coins/images/50390/large/wc-token1.png?1727569464"
-  },
-  {
-    "chainId": 1,
-    "address": "0xcccCCCcCCC33D538DBC2EE4fEab0a7A1FF4e8A94",
-    "name": "Centrifuge",
-    "symbol": "CFG",
-    "decimals": 18,
-    "logoURI": "https://coin-images.coingecko.com/coins/images/55913/large/centrifuge.jpg?1747707741"
-  },
-  {
-    "chainId": 1,
-    "address": "0x4cCe605eD955295432958d8951D0B176C10720d5",
-    "name": "AUDD",
-    "symbol": "AUDD",
-    "decimals": 6,
-    "logoURI": "https://coin-images.coingecko.com/coins/images/33263/large/AUDD-Logo-Blue_512.png?1701319895"
-  },
-  {
-    "chainId": 1,
-    "address": "0x4C1746A800D224393fE2470C70A35717eD4eA5F1",
-    "name": "Plume",
-    "symbol": "PLUME",
-    "decimals": 18,
-    "logoURI": "https://coin-images.coingecko.com/coins/images/53623/large/plume-token.png?1736896935"
-  },
-  {
-    "chainId": 1,
-    "address": "0x0F81001eF0A83ecCE5ccebf63EB302c70a39a654",
-    "name": "Dolomite",
-    "symbol": "DOLO",
-    "decimals": 18,
-    "logoURI": "https://coin-images.coingecko.com/coins/images/54710/large/DOLO-small.png?1745398535"
-  },
-  {
-    "chainId": 1,
-    "address": "0x50f41F589aFACa2EF41FDF590FE7b90cD26DEe64",
-    "name": "Irys",
-    "symbol": "IRYS",
-    "decimals": 18,
-    "logoURI": "https://s2.coinmarketcap.com/static/img/coins/64x64/38978.png"
-  },
-  {
-    "chainId": 1,
-    "address": "0xC9746F73cC33a36c2cD55b8aEFD732586946Cedd",
-    "name": "BOB",
-    "symbol": "BOBBOB",
-    "decimals": 18,
-    "logoURI": "https://coin-images.coingecko.com/coins/images/54720/large/BOB_symbol_colour.png?1741195397"
+    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1776e1F26f98b1A5dF9cD347953a26dd3Cb46671/logo.png"
   },
   {
     "chainId": 1,
@@ -2779,217 +1851,234 @@
   },
   {
     "chainId": 1,
-    "address": "0x8408D45b61f5823298F19a09B53b7339c0280489",
-    "name": "Allora",
-    "symbol": "ALLO",
+    "address": "0x4fE83213D56308330EC302a8BD641f1d0113A4Cc",
+    "name": "NuCypher",
+    "symbol": "NU",
     "decimals": 18,
-    "logoURI": "https://coin-images.coingecko.com/coins/images/70609/large/allo-token.png?1763451165"
+    "logoURI": "https://assets.coingecko.com/coins/images/3318/thumb/photo1198982838879365035.jpg?1547037916"
   },
   {
     "chainId": 1,
-    "address": "0x904567252D8F48555b7447c67dCA23F0372E16be",
-    "name": "Kite",
-    "symbol": "KITE",
+    "address": "0x967da4048cD07aB37855c090aAF366e4ce1b9F48",
+    "name": "Ocean Protocol",
+    "symbol": "OCEAN",
     "decimals": 18,
-    "logoURI": "https://coin-images.coingecko.com/coins/images/70426/large/KITE-ICON.png?1762328605"
+    "logoURI": "https://assets.coingecko.com/coins/images/3687/thumb/ocean-protocol-logo.jpg?1547038686"
   },
   {
     "chainId": 1,
-    "address": "0x5A9610919f5e81183823A2be4Bd1BeB2B4da2a20",
-    "name": "aPriori",
-    "symbol": "APR",
+    "address": "0x8207c1FfC5B6804F6024322CcF34F29c3541Ae26",
+    "name": "Origin Protocol",
+    "symbol": "OGN",
     "decimals": 18,
-    "logoURI": "https://coin-images.coingecko.com/coins/images/70220/large/logo-icon-Gradient.png?1761118006"
+    "logoURI": "https://assets.coingecko.com/coins/images/3296/thumb/op.jpg?1547037878"
   },
   {
     "chainId": 1,
-    "address": "0x01791F726B4103694969820be083196cC7c045fF",
-    "name": "Yield Basis",
-    "symbol": "YB",
+    "address": "0xd26114cd6EE289AccF82350c8d8487fedB8A0C07",
+    "name": "OMG Network",
+    "symbol": "OMG",
     "decimals": 18,
-    "logoURI": "https://coin-images.coingecko.com/coins/images/54871/large/yieldbasis_400x400.png?1760514173"
+    "logoURI": "https://assets.coingecko.com/coins/images/776/thumb/OMG_Network.jpg?1591167168"
   },
   {
     "chainId": 1,
-    "address": "0x1789e0043623282D5DCc7F213d703C6D8BAfBB04",
-    "name": "Linea",
-    "symbol": "LINEA",
+    "address": "0x36E66fbBce51e4cD5bd3C62B637Eb411b18949D4",
+    "name": "Omni Network",
+    "symbol": "OMNI",
     "decimals": 18,
-    "logoURI": "https://coin-images.coingecko.com/coins/images/68507/large/linea-logo.jpeg?1756025484"
+    "logoURI": "https://assets.coingecko.com/coins/images/36465/standard/Symbol-Color.png?1711511095"
   },
   {
     "chainId": 1,
-    "address": "0xCEDbEA37C8872c4171259Cdfd5255CB8923Cf8e7",
-    "name": "Anoma",
-    "symbol": "XAN",
+    "address": "0xfAbA6f8e4a5E8Ab82F62fe7C39859FA577269BE3",
+    "name": "Ondo Finance",
+    "symbol": "ONDO",
     "decimals": 18,
-    "logoURI": "https://coin-images.coingecko.com/coins/images/69380/large/Anoma_Logo_Roundel_RGB_Colour-01.png?1758356672"
+    "logoURI": "https://assets.coingecko.com/coins/images/26580/standard/ONDO.png?1696525656"
   },
   {
     "chainId": 1,
-    "address": "0xf0DB65D17e30a966C2ae6A21f6BBA71cea6e9754",
-    "name": "Lombard",
-    "symbol": "BARD",
+    "address": "0x6F59e0461Ae5E2799F1fB3847f05a63B16d0DbF8",
+    "name": "ORCA Alliance",
+    "symbol": "ORCA",
     "decimals": 18,
-    "logoURI": "https://coin-images.coingecko.com/coins/images/68404/large/bard.png?1755657543"
+    "logoURI": "https://s2.coinmarketcap.com/static/img/coins/64x64/5183.png"
   },
   {
     "chainId": 1,
-    "address": "0x000006c2A22ff4A44ff1f5d0F2ed65F781F55555",
-    "name": "Boundless",
-    "symbol": "ZKC",
+    "address": "0x0258F474786DdFd37ABCE6df6BBb1Dd5dfC4434a",
+    "name": "Orion Protocol",
+    "symbol": "ORN",
+    "decimals": 8,
+    "logoURI": "https://assets.coingecko.com/coins/images/11841/thumb/orion_logo.png?1594943318"
+  },
+  {
+    "name": "Orchid",
+    "address": "0x4575f41308EC1483f3d399aa9a2826d74Da13Deb",
+    "symbol": "OXT",
     "decimals": 18,
-    "logoURI": "https://coin-images.coingecko.com/coins/images/68462/large/boundless.png?1755826792"
+    "chainId": 1,
+    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x4575f41308EC1483f3d399aa9a2826d74Da13Deb/logo.png"
   },
   {
     "chainId": 1,
-    "address": "0xafFbe9a60F1F45E057FD9b6DC70004Bb0Ccc8b99",
-    "name": "Theoriq",
-    "symbol": "THQ",
+    "address": "0xc1D204d77861dEf49b6E769347a883B15EC397Ff",
+    "name": "PayperEx",
+    "symbol": "PAX",
     "decimals": 18,
-    "logoURI": "https://coin-images.coingecko.com/coins/images/67759/large/thq.jpg?1753757049"
+    "logoURI": "https://assets.coingecko.com/coins/images/1601/thumb/pax.png?1547035800"
   },
   {
     "chainId": 1,
-    "address": "0x232CE3bd40fCd6f80f3d55A522d03f25Df784Ee2",
-    "name": "Lighter",
-    "symbol": "LIT",
+    "address": "0x45804880De22913dAFE09f4980848ECE6EcbAf78",
+    "name": "PAX Gold",
+    "symbol": "PAXG",
     "decimals": 18,
-    "logoURI": "https://coin-images.coingecko.com/coins/images/71121/large/lighter.png?1765888098"
+    "logoURI": "https://assets.coingecko.com/coins/images/9519/thumb/paxg.PNG?1568542565"
   },
   {
     "chainId": 1,
-    "address": "0xb48c6B24f36307c7A1f2a9281E978a9ef2902BA5",
-    "name": "ImmuneFi",
-    "symbol": "IMU",
+    "address": "0x0D3CbED3f69EE050668ADF3D9Ea57241cBa33A2B",
+    "name": "PlayDapp",
+    "symbol": "PDA",
     "decimals": 18,
-    "logoURI": "https://s2.coinmarketcap.com/static/img/coins/64x64/39429.png"
+    "logoURI": "https://assets.coingecko.com/coins/images/14316/standard/PDA-symbol.png?1710234068"
   },
   {
     "chainId": 1,
-    "address": "0x56A3BA04E95d34268A19b2a4474DC979baBDaf76",
-    "name": "Sentient",
-    "symbol": "SENT",
+    "address": "0x808507121B80c02388fAd14726482e061B8da827",
+    "name": "Pendle",
+    "symbol": "PENDLE",
     "decimals": 18,
-    "logoURI": "https://coin-images.coingecko.com/coins/images/70508/large/SENTIENT-Icon-BlushForce-L.png?1762267532"
+    "logoURI": "https://coin-images.coingecko.com/coins/images/15069/large/Pendle_Logo_Normal-03.png?1696514728"
   },
   {
     "chainId": 1,
-    "address": "0x086F405146Ce90135750Bbec9A063a8B20A8bfFb",
-    "name": "Brevis",
-    "symbol": "BREV",
+    "address": "0x6982508145454Ce325dDbE47a25d4ec3d2311933",
+    "name": "Pepe",
+    "symbol": "PEPE",
     "decimals": 18,
-    "logoURI": "https://coin-images.coingecko.com/coins/images/71219/large/brevis.png?1766454723"
+    "logoURI": "https://assets.coingecko.com/coins/images/29850/large/pepe-token.jpeg?1682922725"
   },
   {
     "chainId": 1,
-    "address": "0xe1Be424F442D0687129128C6c38aAce44F8c8Dbc",
-    "name": "zkPass",
-    "symbol": "ZKP",
+    "address": "0xbC396689893D065F41bc2C6EcbeE5e0085233447",
+    "name": "Perpetual Protocol",
+    "symbol": "PERP",
     "decimals": 18,
-    "logoURI": "https://coin-images.coingecko.com/coins/images/70273/large/zkpass.png?1761379373"
+    "logoURI": "https://assets.coingecko.com/coins/images/12381/thumb/60d18e06844a844ad75901a9_mark_only_03.png?1628674771"
   },
   {
     "chainId": 1,
-    "address": "0xB5F7b021a78f470d31D762C1DDA05ea549904fbd",
-    "name": "Rayls",
-    "symbol": "RLS",
+    "address": "0x7613C48E0cd50E42dD9Bf0f6c235063145f6f8DC",
+    "name": "Pirate Nation",
+    "symbol": "PIRATE",
     "decimals": 18,
-    "logoURI": "https://coin-images.coingecko.com/coins/images/70091/large/cgrLS.png?1760541265"
+    "logoURI": "https://assets.coingecko.com/coins/images/38524/standard/_Pirate_Transparent_200x200.png"
   },
   {
     "chainId": 1,
-    "address": "0xA27EC0006e59f245217Ff08CD52A7E8b169E62D2",
-    "name": "Aztec",
-    "symbol": "AZTEC",
+    "address": "0xD8912C10681D8B21Fd3742244f44658dBA12264E",
+    "name": "Pluton",
+    "symbol": "PLU",
     "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/70681/large/aztec.png?1763091883"
+    "logoURI": "https://assets.coingecko.com/coins/images/1241/thumb/pluton.png?1548331624"
   },
   {
     "chainId": 1,
-    "address": "0xdeF1b2D939EdC0E4d35806c59b3166F790175afe",
-    "name": "Infinex",
-    "symbol": "INX",
+    "address": "0x4C1746A800D224393fE2470C70A35717eD4eA5F1",
+    "name": "Plume",
+    "symbol": "PLUME",
     "decimals": 18,
-    "logoURI": "https://coin-images.coingecko.com/coins/images/70868/large/infinex.png?1764322875"
+    "logoURI": "https://coin-images.coingecko.com/coins/images/53623/large/plume-token.png?1736896935"
   },
   {
     "chainId": 1,
-    "address": "0xA12CC123ba206d4031D1c7f6223D1C2Ec249f4f3",
-    "name": "Zama",
-    "symbol": "ZAMA",
+    "address": "0x455e53CBB86018Ac2B8092FdCd39d8444aFFC3F6",
+    "name": "Polygon Ecosystem Token",
+    "symbol": "POL",
     "decimals": 18,
-    "logoURI": "https://coin-images.coingecko.com/coins/images/70921/large/zama.png?1764591992"
+    "logoURI": "https://assets.coingecko.com/coins/images/32440/large/polygon.png?1698233684"
   },
   {
     "chainId": 1,
-    "address": "0x228bEC415adE4b61D7CaF0adf8C91EAc587BA369",
-    "name": "Tria",
-    "symbol": "TRIA",
+    "address": "0x83e6f1E41cdd28eAcEB20Cb649155049Fac3D5Aa",
+    "name": "Polkastarter",
+    "symbol": "POLS",
     "decimals": 18,
-    "logoURI": "https://s2.coinmarketcap.com/static/img/coins/64x64/39382.png"
+    "logoURI": "https://assets.coingecko.com/coins/images/12648/thumb/polkastarter.png?1609813702"
   },
   {
     "chainId": 1,
-    "address": "0x031De51F3E8016514Bd0963d0B2AB825A591Db9A",
-    "name": "Espresso",
-    "symbol": "ESP",
+    "address": "0x9992eC3cF6A55b00978cdDF2b27BC6882d88D1eC",
+    "name": "Polymath",
+    "symbol": "POLY",
     "decimals": 18,
-    "logoURI": "https://coin-images.coingecko.com/coins/images/67626/large/espresso.jpg?1753324525"
+    "logoURI": "https://assets.coingecko.com/coins/images/2784/thumb/inKkF01.png?1605007034"
   },
   {
     "chainId": 1,
-    "address": "0x7C135549504245B5eAe64fc0E99Fa5ebabb8e35D",
-    "name": "Fidelity Digital Dollar",
-    "symbol": "FIDD",
-    "decimals": 18,
-    "logoURI": "https://coin-images.coingecko.com/coins/images/102171776/large/FIDD-Green_%28792px%29.png?1769612802"
+    "name": "Marlin",
+    "symbol": "POND",
+    "logoURI": "https://assets.coingecko.com/coins/images/8903/thumb/POND_200x200.png?1622515451",
+    "address": "0x57B946008913B82E4dF85f501cbAeD910e58D26C",
+    "decimals": 18
   },
   {
     "chainId": 1,
-    "address": "0x68749665FF8D2d112Fa859AA293F07A622782F38",
-    "name": "Tether Gold",
-    "symbol": "XAUT",
+    "address": "0x1Bbe973BeF3a977Fc51CbED703E8ffDEfE001Fed",
+    "name": "Portal",
+    "symbol": "PORTAL",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/35436/standard/portal.jpeg"
+  },
+  {
+    "chainId": 1,
+    "address": "0x595832F8FC6BF59c85C527fEC3740A1b7a361269",
+    "name": "Power Ledger",
+    "symbol": "POWR",
     "decimals": 6,
-    "logoURI": "https://coin-images.coingecko.com/coins/images/10481/large/Tether_Gold.png?1696510471"
+    "logoURI": "https://assets.coingecko.com/coins/images/1104/thumb/power-ledger.png?1547035082"
   },
   {
     "chainId": 1,
-    "address": "0x32b4d049fE4c888D2b92eEcaf729F44DF6B1F36E",
-    "name": "ROBO Token",
-    "symbol": "ROBO",
+    "address": "0xb23d80f5FefcDDaa212212F028021B41DEd428CF",
+    "name": "Prime",
+    "symbol": "PRIME",
     "decimals": 18,
-    "logoURI": "https://coin-images.coingecko.com/coins/images/102172005/large/ROBO.png?1770925648"
+    "logoURI": "https://assets.coingecko.com/coins/images/29053/large/PRIMELOGOOO.png?1676976222"
   },
   {
     "chainId": 1,
-    "address": "0x2798b1cC5A993085E8A9D46e80499F1B63f42204",
-    "name": "ETHGas",
-    "symbol": "GWEI",
+    "address": "0x226bb599a12C826476e3A771454697EA52E9E220",
+    "name": "Propy",
+    "symbol": "PRO",
+    "decimals": 8,
+    "logoURI": "https://assets.coingecko.com/coins/images/869/thumb/propy.png?1548332100"
+  },
+  {
+    "chainId": 1,
+    "address": "0x6BEF15D938d4E72056AC92Ea4bDD0D76B1C4ad29",
+    "name": "Succinct",
+    "symbol": "PROVE",
     "decimals": 18,
-    "logoURI": "https://coin-images.coingecko.com/coins/images/71375/large/ethgas_token_200.png?1769055039"
+    "logoURI": "https://coin-images.coingecko.com/coins/images/67905/large/succinct-logo.png?1754228574"
   },
   {
     "chainId": 1,
-    "address": "0x2aeAbde1aB736c59E9A19BeD67681869eEF39526",
-    "name": "DOVU",
-    "symbol": "DOVU",
-    "decimals": 8,
-    "logoURI": "https://coin-images.coingecko.com/coins/images/31930/large/Dovu_Icon_Black_%281%29.png?1696530738"
+    "name": "PARSIQ",
+    "symbol": "PRQ",
+    "logoURI": "https://assets.coingecko.com/coins/images/11973/thumb/DsNgK0O.png?1596590280",
+    "address": "0x362bc847A3a9637d3af6624EeC853618a43ed7D2",
+    "decimals": 18
   },
   {
     "chainId": 1,
-    "address": "0x925206b8a707096Ed26ae47C84747fE0bb734F59",
-    "name": "WhiteBIT Coin",
-    "symbol": "WBT",
-    "decimals": 8,
-    "logoURI": "https://coin-images.coingecko.com/coins/images/27045/large/wbt_token.png?1696526096"
-  },
-  {
-    "chainId": 1,
-    "address": "0xd8A271974E8EdAE9D7b58e3370dc1669427503F4",
-    "name": "Fluent",
-    "symbol": "BLEND",
+    "name": "pSTAKE Finance",
+    "symbol": "PSTAKE",
+    "logoURI": "https://assets.coingecko.com/coins/images/23931/thumb/PSTAKE_Dark.png?1645709930",
+    "address": "0xfB5c6815cA3AC72Ce9F5006869AE67f18bF77006",
     "decimals": 18
   },
   {
@@ -3002,11 +2091,499 @@
   },
   {
     "chainId": 1,
-    "address": "0x8B1484d57abBE239bB280661377363b03c89CaEa",
-    "name": "ADI",
-    "symbol": "ADI",
+    "address": "0x4d1C297d39C5c1277964D0E3f8Aa901493664530",
+    "name": "Puffer Finance",
+    "symbol": "PUFFER",
     "decimals": 18,
-    "logoURI": "https://coin-images.coingecko.com/coins/images/68846/large/ADI_Token-min.png?1765296433"
+    "logoURI": "https://assets.coingecko.com/coins/images/50630/large/puffer.jpg?1728545297"
+  },
+  {
+    "chainId": 1,
+    "address": "0x6c3ea9036406852006290770BEdFcAbA0e23A0e8",
+    "name": "PayPal USD",
+    "symbol": "PYUSD",
+    "decimals": 6,
+    "logoURI": "https://assets.coingecko.com/coins/images/31212/large/PYUSD_Logo_%282%29.png?1691458314"
+  },
+  {
+    "chainId": 1,
+    "address": "0x4a220E6096B25EADb88358cb44068A3248254675",
+    "name": "Quant",
+    "symbol": "QNT",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/3370/thumb/5ZOu7brX_400x400.jpg?1612437252"
+  },
+  {
+    "chainId": 1,
+    "name": "Qredo",
+    "symbol": "QRDO",
+    "logoURI": "https://assets.coingecko.com/coins/images/17541/thumb/qrdo.png?1630637735",
+    "address": "0x4123a133ae3c521FD134D7b13A2dEC35b56c2463",
+    "decimals": 8
+  },
+  {
+    "chainId": 1,
+    "address": "0x99ea4dB9EE77ACD40B119BD1dC4E33e1C070b80d",
+    "name": "Quantstamp",
+    "symbol": "QSP",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/1219/thumb/0_E0kZjb4dG4hUnoDD_.png?1604815917"
+  },
+  {
+    "chainId": 1,
+    "address": "0x6c28AeF8977c9B773996d0e8376d2EE379446F2f",
+    "name": "Quickswap",
+    "symbol": "QUICK",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/13970/thumb/1_pOU6pBMEmiL-ZJVb0CYRjQ.png?1613386659"
+  },
+  {
+    "chainId": 1,
+    "address": "0x31c8EAcBFFdD875c74b94b077895Bd78CF1E64A3",
+    "name": "Radicle",
+    "symbol": "RAD",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/14013/thumb/radicle.png?1614402918"
+  },
+  {
+    "chainId": 1,
+    "address": "0x03ab458634910AaD20eF5f1C8ee96F1D6ac54919",
+    "name": "Rai Reflex Index",
+    "symbol": "RAI",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/14004/thumb/RAI-logo-coin.png?1613592334"
+  },
+  {
+    "chainId": 1,
+    "address": "0xba5BDe662c17e2aDFF1075610382B9B691296350",
+    "name": "SuperRare",
+    "symbol": "RARE",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/17753/thumb/RARE.jpg?1629220534"
+  },
+  {
+    "chainId": 1,
+    "address": "0xFca59Cd816aB1eaD66534D82bc21E7515cE441CF",
+    "name": "Rarible",
+    "symbol": "RARI",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/11845/thumb/Rari.png?1594946953"
+  },
+  {
+    "chainId": 1,
+    "address": "0xA4EED63db85311E22dF4473f87CcfC3DaDCFA3E3",
+    "name": "Rubic",
+    "symbol": "RBC",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/12629/thumb/200x200.png?1607952509"
+  },
+  {
+    "chainId": 1,
+    "address": "0x6123B0049F904d730dB3C36a31167D9d4121fA6B",
+    "name": "Ribbon Finance",
+    "symbol": "RBN",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/15823/thumb/RBN_64x64.png?1633529723"
+  },
+  {
+    "chainId": 1,
+    "address": "0xc43C6bfeDA065fE2c4c11765Bf838789bd0BB5dE",
+    "name": "Redstone",
+    "symbol": "RED",
+    "decimals": 18,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/53640/large/RedStone_Logo_New_White.png?1740640919"
+  },
+  {
+    "name": "Republic Token",
+    "address": "0x408e41876cCCDC0F92210600ef50372656052a38",
+    "symbol": "REN",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x408e41876cCCDC0F92210600ef50372656052a38/logo.png"
+  },
+  {
+    "name": "Reputation Augur v1",
+    "address": "0x1985365e9f78359a9B6AD760e32412f4a445E862",
+    "symbol": "REP",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x1985365e9f78359a9B6AD760e32412f4a445E862/logo.png"
+  },
+  {
+    "name": "Reputation Augur v2",
+    "address": "0x221657776846890989a759BA2973e427DfF5C9bB",
+    "symbol": "REPv2",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x221657776846890989a759BA2973e427DfF5C9bB/logo.png"
+  },
+  {
+    "chainId": 1,
+    "address": "0x8f8221aFbB33998d8584A2B05749bA73c37a938a",
+    "name": "Request",
+    "symbol": "REQ",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/1031/thumb/Request_icon_green.png?1643250951"
+  },
+  {
+    "chainId": 1,
+    "name": "REVV",
+    "symbol": "REVV",
+    "logoURI": "https://assets.coingecko.com/coins/images/12373/thumb/REVV_TOKEN_Refined_2021_%281%29.png?1627652390",
+    "address": "0x557B933a7C2c45672B610F8954A3deB39a51A8Ca",
+    "decimals": 18
+  },
+  {
+    "chainId": 1,
+    "address": "0x3B50805453023a91a8bf641e279401a0b23FA6F9",
+    "name": "Renzo",
+    "symbol": "REZ",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/37327/standard/renzo_200x200.png?1714025012"
+  },
+  {
+    "chainId": 1,
+    "address": "0xD291E7a03283640FDc51b121aC401383A46cC623",
+    "name": "Rari Governance Token",
+    "symbol": "RGT",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/12900/thumb/Rari_Logo_Transparent.png?1613978014"
+  },
+  {
+    "chainId": 1,
+    "address": "0x607F4C5BB672230e8672085532f7e901544a7375",
+    "name": "iExec RLC",
+    "symbol": "RLC",
+    "decimals": 9,
+    "logoURI": "https://assets.coingecko.com/coins/images/646/thumb/pL1VuXm.png?1604543202"
+  },
+  {
+    "chainId": 1,
+    "address": "0xB5F7b021a78f470d31D762C1DDA05ea549904fbd",
+    "name": "Rayls",
+    "symbol": "RLS",
+    "decimals": 18,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/70091/large/cgrLS.png?1760541265"
+  },
+  {
+    "chainId": 1,
+    "address": "0x8292Bb45bf1Ee4d140127049757C2E0fF06317eD",
+    "name": "RLUSD",
+    "symbol": "RLUSD",
+    "decimals": 18,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/39651/large/RLUSD_200x200_(1).png?1727376633"
+  },
+  {
+    "chainId": 1,
+    "address": "0xf1f955016EcbCd7321c7266BccFB96c68ea5E49b",
+    "name": "Rally",
+    "symbol": "RLY",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/12843/thumb/image.png?1611212077"
+  },
+  {
+    "chainId": 1,
+    "address": "0x6De037ef9aD2725EB40118Bb1702EBb27e4Aeb24",
+    "name": "Render Token",
+    "symbol": "RNDR",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/11636/thumb/rndr.png?1638840934"
+  },
+  {
+    "chainId": 1,
+    "address": "0x32b4d049fE4c888D2b92eEcaf729F44DF6B1F36E",
+    "name": "ROBO Token",
+    "symbol": "ROBO",
+    "decimals": 18,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/102172005/large/ROBO.png?1770925648"
+  },
+  {
+    "chainId": 1,
+    "name": "Rook",
+    "symbol": "ROOK",
+    "logoURI": "https://assets.coingecko.com/coins/images/13005/thumb/keeper_dao_logo.jpg?1604316506",
+    "address": "0xfA5047c9c78B8877af97BDcb85Db743fD7313d4a",
+    "decimals": 18
+  },
+  {
+    "chainId": 1,
+    "address": "0xD33526068D116cE69F19A9ee46F0bd304F21A51f",
+    "name": "Rocket Pool Protocol",
+    "symbol": "RPL",
+    "decimals": 18,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/2090/large/rocket_pool_%28RPL%29.png?1696503058"
+  },
+  {
+    "chainId": 1,
+    "address": "0x320623b8E4fF03373931769A31Fc52A4E78B5d70",
+    "name": "Reserve Rights",
+    "symbol": "RSR",
+    "decimals": 18,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/8365/large/RSR_Blue_Circle_1000.png?1721777856"
+  },
+  {
+    "chainId": 1,
+    "address": "0x5aFE3855358E112B5647B952709E6165e1c1eEEe",
+    "name": "Safe",
+    "symbol": "SAFE",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/27032/standard/Artboard_1_copy_8circle-1.png?1696526084"
+  },
+  {
+    "chainId": 1,
+    "address": "0x3845badAde8e6dFF049820680d1F14bD3903a5d0",
+    "name": "The Sandbox",
+    "symbol": "SAND",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/12129/thumb/sandbox_logo.jpg?1597397942"
+  },
+  {
+    "chainId": 1,
+    "address": "0x30D20208d987713f46DFD34EF128Bb16C404D10f",
+    "name": "Stader",
+    "symbol": "SD",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/20658/standard/SD_Token_Logo.png"
+  },
+  {
+    "chainId": 1,
+    "address": "0x56A3BA04E95d34268A19b2a4474DC979baBDaf76",
+    "name": "Sentient",
+    "symbol": "SENT",
+    "decimals": 18,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/70508/large/SENTIENT-Icon-BlushForce-L.png?1762267532"
+  },
+  {
+    "chainId": 1,
+    "address": "0x95aD61b0a150d79219dCF64E1E6Cc01f0B64C4cE",
+    "name": "Shiba Inu",
+    "symbol": "SHIB",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/11939/thumb/shiba.png?1622619446"
+  },
+  {
+    "chainId": 1,
+    "address": "0x7C84e62859D0715eb77d1b1C4154Ecd6aBB21BEC",
+    "name": "Shping",
+    "symbol": "SHPING",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/2588/thumb/r_yabKKi_400x400.jpg?1639470164"
+  },
+  {
+    "chainId": 1,
+    "address": "0x00c83aeCC790e8a4453e5dD3B0B4b3680501a7A7",
+    "name": "SKALE",
+    "symbol": "SKL",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/13245/thumb/SKALE_token_300x300.png?1606789574"
+  },
+  {
+    "chainId": 1,
+    "address": "0x56072C95FAA701256059aa122697B133aDEd9279",
+    "name": "SKY Governance Token",
+    "symbol": "SKY",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/39925/large/sky.jpg?1724827980"
+  },
+  {
+    "chainId": 1,
+    "address": "0xCC8Fa225D80b9c7D42F96e9570156c65D6cAAa25",
+    "name": "Smooth Love Potion",
+    "symbol": "SLP",
+    "decimals": 0,
+    "logoURI": "https://assets.coingecko.com/coins/images/10366/thumb/SLP.png?1578640057"
+  },
+  {
+    "chainId": 1,
+    "address": "0x744d70FDBE2Ba4CF95131626614a1763DF805B9E",
+    "name": "Status",
+    "symbol": "SNT",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/779/thumb/status.png?1548610778"
+  },
+  {
+    "name": "Synthetix Network Token",
+    "address": "0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F",
+    "symbol": "SNX",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F/logo.png"
+  },
+  {
+    "chainId": 1,
+    "address": "0x23B608675a2B2fB1890d3ABBd85c5775c51691d5",
+    "name": "Unisocks",
+    "symbol": "SOCKS",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/10717/thumb/qFrcoiM.png?1582525244"
+  },
+  {
+    "chainId": 1,
+    "address": "0xD31a59c85aE9D8edEFeC411D448f90841571b89c",
+    "name": "SOL Wormhole ",
+    "symbol": "SOL",
+    "decimals": 9,
+    "logoURI": "https://assets.coingecko.com/coins/images/22876/thumb/SOL_wh_small.png?1644224316"
+  },
+  {
+    "chainId": 1,
+    "address": "0x090185f2135308BaD17527004364eBcC2D37e5F6",
+    "name": "Spell Token",
+    "symbol": "SPELL",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/15861/thumb/abracadabra-3.png?1622544862"
+  },
+  {
+    "chainId": 1,
+    "address": "0xc20059e0317DE91738d13af027DfC4a50781b066",
+    "name": "Spark",
+    "symbol": "SPK",
+    "decimals": 18,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/38637/large/Spark-Logomark-RGB.png?1744878896"
+  },
+  {
+    "chainId": 1,
+    "address": "0xE0f63A424a4439cBE457D80E4f4b51aD25b2c56C",
+    "name": "SPX6900",
+    "symbol": "SPX",
+    "decimals": 8,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/31401/large/sticker_(1).jpg?1702371083"
+  },
+  {
+    "chainId": 1,
+    "name": "Stargate Finance",
+    "symbol": "STG",
+    "logoURI": "https://assets.coingecko.com/coins/images/24413/thumb/STG_LOGO.png?1647654518",
+    "address": "0xAf5191B0De278C7286d6C7CC6ab6BB8A73bA2Cd6",
+    "decimals": 18
+  },
+  {
+    "name": "Storj Token",
+    "address": "0xB64ef51C888972c908CFacf59B47C1AfBC0Ab8aC",
+    "symbol": "STORJ",
+    "decimals": 8,
+    "chainId": 1,
+    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xB64ef51C888972c908CFacf59B47C1AfBC0Ab8aC/logo.png"
+  },
+  {
+    "chainId": 1,
+    "address": "0xCa14007Eff0dB1f8135f4C25B34De49AB0d42766",
+    "name": "Starknet",
+    "symbol": "STRK",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/26433/standard/starknet.png?1696525507"
+  },
+  {
+    "chainId": 1,
+    "address": "0x006BeA43Baa3f7A6f765F14f10A1a1b08334EF45",
+    "name": "Stox",
+    "symbol": "STX",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/1230/thumb/stox-token.png?1547035256"
+  },
+  {
+    "chainId": 1,
+    "address": "0x0763fdCCF1aE541A5961815C0872A8c5Bc6DE4d7",
+    "name": "SUKU",
+    "symbol": "SUKU",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/11969/thumb/UmfW5S6f_400x400.jpg?1596602238"
+  },
+  {
+    "chainId": 1,
+    "address": "0xe53EC727dbDEB9E2d5456c3be40cFF031AB40A55",
+    "name": "SuperFarm",
+    "symbol": "SUPER",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/14040/thumb/6YPdWn6.png?1613975899"
+  },
+  {
+    "name": "Synth sUSD",
+    "address": "0x57Ab1ec28D129707052df4dF418D58a2D46d5f51",
+    "symbol": "sUSD",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://assets.coingecko.com/coins/images/5013/thumb/sUSD.png?1616150765"
+  },
+  {
+    "chainId": 1,
+    "address": "0x6B3595068778DD592e39A122f4f5a5cF09C90fE2",
+    "name": "Sushi",
+    "symbol": "SUSHI",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/12271/thumb/512x512_Logo_no_chop.png?1606986688"
+  },
+  {
+    "chainId": 1,
+    "address": "0x0a6E7Ba5042B38349e437ec6Db6214AEC7B35676",
+    "name": "Swell",
+    "symbol": "SWELL",
+    "decimals": 18,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/28777/large/swell1.png?1727899715"
+  },
+  {
+    "chainId": 1,
+    "name": "SWFTCOIN",
+    "symbol": "SWFTC",
+    "logoURI": "https://assets.coingecko.com/coins/images/2346/thumb/SWFTCoin.jpg?1618392022",
+    "address": "0x0bb217E40F8a5Cb79Adf04E1aAb60E5abd0dfC1e",
+    "decimals": 8
+  },
+  {
+    "chainId": 1,
+    "name": "Swipe",
+    "symbol": "SXP",
+    "logoURI": "https://assets.coingecko.com/coins/images/9368/thumb/swipe.png?1566792311",
+    "address": "0x8CE9137d39326AD0cD6491fb5CC0CbA0e089b6A9",
+    "decimals": 18
+  },
+  {
+    "chainId": 1,
+    "address": "0xE6Bfd33F52d82Ccb5b37E16D3dD81f9FFDAbB195",
+    "name": "Space and Time",
+    "symbol": "SXT",
+    "decimals": 18,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/55424/large/sxt-token_circle.jpg?1745935919"
+  },
+  {
+    "chainId": 1,
+    "name": "Sylo",
+    "symbol": "SYLO",
+    "logoURI": "https://assets.coingecko.com/coins/images/6430/thumb/SYLO.svg?1589527756",
+    "address": "0xf293d23BF2CDc05411Ca0edDD588eb1977e8dcd4",
+    "decimals": 18
+  },
+  {
+    "chainId": 1,
+    "address": "0x0f2D719407FdBeFF09D87557AbB7232601FD9F29",
+    "name": "Synapse",
+    "symbol": "SYN",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/18024/thumb/syn.png?1635002049"
+  },
+  {
+    "chainId": 1,
+    "address": "0x643C4E15d7d62Ad0aBeC4a9BD4b001aA3Ef52d66",
+    "name": "Syrup Token",
+    "symbol": "SYRUP",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/51232/standard/IMG_7420.png?1730831572"
+  },
+  {
+    "chainId": 1,
+    "name": "Threshold Network",
+    "symbol": "T",
+    "logoURI": "https://assets.coingecko.com/coins/images/22228/thumb/nFPNiSbL_400x400.jpg?1641220340",
+    "address": "0xCdF7028ceAB81fA0C6971208e83fa7872994beE5",
+    "decimals": 18
+  },
+  {
+    "chainId": 1,
+    "address": "0x18084fbA666a33d37592fA2633fD49a74DD93a88",
+    "name": "tBTC",
+    "symbol": "tBTC",
+    "decimals": 18,
+    "logoURI": "https://raw.githubusercontent.com/uniswap/assets/master/blockchains/ethereum/assets/0x18084fbA666a33d37592fA2633fD49a74DD93a88/logo.png"
   },
   {
     "chainId": 1,
@@ -3018,11 +2595,332 @@
   },
   {
     "chainId": 1,
-    "address": "0xa3EE21C306A700E682AbCdfe9BaA6A08F3820419",
-    "name": "Creditcoin",
-    "symbol": "CTC",
+    "address": "0xC3d21f79C3120A4fFda7A535f8005a7c297799bF",
+    "name": "Term Finance",
+    "symbol": "TERM",
     "decimals": 18,
-    "logoURI": "https://coin-images.coingecko.com/coins/images/10569/large/Creditcoin_Symbol_dark56.png?1737796066"
+    "logoURI": "https://coin-images.coingecko.com/coins/images/38142/large/terms.png?1716630303"
+  },
+  {
+    "chainId": 1,
+    "address": "0xafFbe9a60F1F45E057FD9b6DC70004Bb0Ccc8b99",
+    "name": "Theoriq",
+    "symbol": "THQ",
+    "decimals": 18,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/67759/large/thq.jpg?1753757049"
+  },
+  {
+    "chainId": 1,
+    "name": "ChronoTech",
+    "symbol": "TIME",
+    "logoURI": "https://assets.coingecko.com/coins/images/604/thumb/time-32x32.png?1627130666",
+    "address": "0x485d17A6f1B8780392d53D64751824253011A260",
+    "decimals": 8
+  },
+  {
+    "chainId": 1,
+    "name": "Alien Worlds",
+    "symbol": "TLM",
+    "logoURI": "https://assets.coingecko.com/coins/images/14676/thumb/kY-C4o7RThfWrDQsLCAG4q4clZhBDDfJQVhWUEKxXAzyQYMj4Jmq1zmFwpRqxhAJFPOa0AsW_PTSshoPuMnXNwq3rU7Imp15QimXTjlXMx0nC088mt1rIwRs75GnLLugWjSllxgzvQ9YrP4tBgclK4_rb17hjnusGj_c0u2fx0AvVokjSNB-v2poTj0xT9BZRCbzRE3-lF1.jpg?1617700061",
+    "address": "0x888888848B652B3E3a0f34c96E00EEC0F3a23F72",
+    "decimals": 4
+  },
+  {
+    "chainId": 1,
+    "address": "0x2e9d63788249371f1DFC918a52f8d799F4a38C94",
+    "name": "Tokemak",
+    "symbol": "TOKE",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/17495/thumb/tokemak-avatar-200px-black.png?1628131614"
+  },
+  {
+    "chainId": 1,
+    "address": "0x4507cEf57C46789eF8d1a19EA45f4216bae2B528",
+    "name": "TokenFi",
+    "symbol": "TOKEN",
+    "decimals": 9,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/32507/large/MAIN_TokenFi_logo_icon.png?1698918427"
+  },
+  {
+    "chainId": 1,
+    "name": "TE FOOD",
+    "symbol": "TONE",
+    "logoURI": "https://assets.coingecko.com/coins/images/2325/thumb/tec.png?1547036538",
+    "address": "0x2Ab6Bb8408ca3199B8Fa6C92d5b455F820Af03c4",
+    "decimals": 18
+  },
+  {
+    "chainId": 1,
+    "address": "0xaA7a9CA87d3694B5755f213B5D04094b8d0F0A6F",
+    "name": "OriginTrail",
+    "symbol": "TRAC",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/1877/thumb/TRAC.jpg?1635134367"
+  },
+  {
+    "chainId": 1,
+    "address": "0x88dF592F8eb5D7Bd38bFeF7dEb0fBc02cf3778a0",
+    "name": "Tellor",
+    "symbol": "TRB",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/9644/thumb/Blk_icon_current.png?1584980686"
+  },
+  {
+    "chainId": 1,
+    "address": "0x77146784315Ba81904d654466968e3a7c196d1f3",
+    "name": "Treehouse Token",
+    "symbol": "TREE",
+    "decimals": 18,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/67664/large/TREE_logo.png?1753601041"
+  },
+  {
+    "chainId": 1,
+    "address": "0x228bEC415adE4b61D7CaF0adf8C91EAc587BA369",
+    "name": "Tria",
+    "symbol": "TRIA",
+    "decimals": 18,
+    "logoURI": "https://s2.coinmarketcap.com/static/img/coins/64x64/39382.png"
+  },
+  {
+    "chainId": 1,
+    "address": "0xc7283b66Eb1EB5FB86327f08e1B5816b0720212B",
+    "name": "Tribe",
+    "symbol": "TRIBE",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/14575/thumb/tribe.PNG?1617487954"
+  },
+  {
+    "chainId": 1,
+    "address": "0x4C19596f5aAfF459fA38B0f7eD92F11AE6543784",
+    "name": "TrueFi",
+    "symbol": "TRU",
+    "decimals": 8,
+    "logoURI": "https://assets.coingecko.com/coins/images/13180/thumb/truefi_glyph_color.png?1617610941"
+  },
+  {
+    "chainId": 1,
+    "address": "0xA35923162C49cF95e6BF26623385eb431ad920D3",
+    "name": "Turbo",
+    "symbol": "TURBO",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/30117/large/TurboMark-QL_200.png?1708079597"
+  },
+  {
+    "chainId": 1,
+    "name": "The Virtua Kolect",
+    "symbol": "TVK",
+    "logoURI": "https://assets.coingecko.com/coins/images/13330/thumb/virtua_original.png?1656043619",
+    "address": "0xd084B83C305daFD76AE3E1b4E1F1fe2eCcCb3988",
+    "decimals": 18
+  },
+  {
+    "name": "UMA Voting Token v1",
+    "address": "0x04Fa0d235C4abf4BcF4787aF4CF447DE572eF828",
+    "symbol": "UMA",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x04Fa0d235C4abf4BcF4787aF4CF447DE572eF828/logo.png"
+  },
+  {
+    "chainId": 1,
+    "address": "0x441761326490cACF7aF299725B6292597EE822c2",
+    "name": "Unifi Protocol DAO",
+    "symbol": "UNFI",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/13152/thumb/logo-2.png?1605748967"
+  },
+  {
+    "name": "Uniswap",
+    "address": "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984",
+    "symbol": "UNI",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "ipfs://QmXttGpZrECX5qCyXbBQiqgQNytVGeZW5Anewvh2jc4psg"
+  },
+  {
+    "chainId": 1,
+    "address": "0x70D2b7C19352bB76e4409858FF5746e500f2B67c",
+    "name": "Pawtocol",
+    "symbol": "UPI",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/12186/thumb/pawtocol.jpg?1597962008"
+  },
+  {
+    "chainId": 1,
+    "address": "0x8d0D000Ee44948FC98c9B98A4FA4921476f08B0d",
+    "name": "World Liberty Financial USD",
+    "symbol": "USD1",
+    "decimals": 18,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/54977/large/USD1_1000x1000_transparent.png?1749297002"
+  },
+  {
+    "name": "USDCoin",
+    "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+    "symbol": "USDC",
+    "decimals": 6,
+    "chainId": 1,
+    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48/logo.png",
+    "extensions": {
+      "bridgeInfo": {
+        "42161": {
+          "tokenAddress": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831"
+        },
+        "42220": {
+          "tokenAddress": "0xcebA9300f2b948710d2653dD7B07f33A8B32118C"
+        }
+      }
+    }
+  },
+  {
+    "chainId": 1,
+    "address": "0xe343167631d89B6Ffc58B88d6b7fB0228795491D",
+    "name": "Global Dollar",
+    "symbol": "USDG",
+    "decimals": 6,
+    "logoURI": "https://assets.coingecko.com/coins/images/51281/large/GDN_USDG_Token_200x200.png"
+  },
+  {
+    "chainId": 1,
+    "address": "0x8E870D67F660D95d5be530380D0eC0bd388289E1",
+    "name": "Pax Dollar",
+    "symbol": "USDP",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/6013/standard/Pax_Dollar.png?1696506427"
+  },
+  {
+    "chainId": 1,
+    "address": "0xc83e27f270cce0A3A3A29521173a83F402c1768b",
+    "name": "Quantoz USDQ",
+    "symbol": "USDQ",
+    "decimals": 6,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/51852/large/USDQ_1000px_Color.png?1732071232"
+  },
+  {
+    "chainId": 1,
+    "address": "0x7B43E3875440B44613DC3bC08E7763e6Da63C8f8",
+    "name": "StablR USD",
+    "symbol": "USDR",
+    "decimals": 6,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/53721/large/stablrusd-logo.png?1737126629"
+  },
+  {
+    "chainId": 1,
+    "address": "0xdC035D45d973E3EC169d2276DDab16f1e407384F",
+    "name": "USDS Stablecoin",
+    "symbol": "USDS",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/39926/large/usds.webp?1726666683"
+  },
+  {
+    "name": "Tether USD",
+    "address": "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+    "symbol": "USDT",
+    "decimals": 6,
+    "chainId": 1,
+    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xdAC17F958D2ee523a2206206994597C13D831ec7/logo.png",
+    "extensions": {
+      "bridgeInfo": {
+        "42220": {
+          "tokenAddress": "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e"
+        }
+      }
+    }
+  },
+  {
+    "chainId": 1,
+    "address": "0xC4441c2BE5d8fA8126822B9929CA0b81Ea0DE38E",
+    "name": "USUAL",
+    "symbol": "USUAL",
+    "decimals": 18,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/51091/large/USUAL.jpg?1730035787"
+  },
+  {
+    "chainId": 1,
+    "address": "0x8DE5B80a0C1B02Fe4976851D030B36122dbb8624",
+    "name": "VANRY",
+    "symbol": "VANRY",
+    "decimals": 18,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/33466/large/apple-touch-icon.png?1701942541"
+  },
+  {
+    "chainId": 1,
+    "address": "0x3C4B6E6e1eA3D4863700D7F76b36B7f3D3f13E3d",
+    "name": "Voyager Token",
+    "symbol": "VGX",
+    "decimals": 8,
+    "logoURI": "https://assets.coingecko.com/coins/images/794/thumb/Voyager-vgx.png?1575693595"
+  },
+  {
+    "chainId": 1,
+    "name": "Wrapped Ampleforth",
+    "symbol": "WAMPL",
+    "logoURI": "https://assets.coingecko.com/coins/images/20825/thumb/photo_2021-11-25_02-05-11.jpg?1637811951",
+    "address": "0xEDB171C18cE90B633DB442f2A6F72874093b49Ef",
+    "decimals": 18
+  },
+  {
+    "chainId": 1,
+    "address": "0xf983da3ca66964C02628189Ea8Ca99fa9E24f66c",
+    "name": "Wrapped Analog One Token",
+    "symbol": "WANLOG",
+    "decimals": 12,
+    "logoURI": "https://assets.kraken.com/marketing/web/icons-uni-webp/s_anlog.webp?i=kds"
+  },
+  {
+    "chainId": 1,
+    "address": "0x925206b8a707096Ed26ae47C84747fE0bb734F59",
+    "name": "WhiteBIT Coin",
+    "symbol": "WBT",
+    "decimals": 8,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/27045/large/wbt_token.png?1696526096"
+  },
+  {
+    "name": "Wrapped BTC",
+    "address": "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599",
+    "symbol": "WBTC",
+    "decimals": 8,
+    "chainId": 1,
+    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599/logo.png"
+  },
+  {
+    "chainId": 1,
+    "name": "Wrapped Centrifuge",
+    "symbol": "WCFG",
+    "logoURI": "https://assets.coingecko.com/coins/images/17106/thumb/WCFG.jpg?1626266462",
+    "address": "0xc221b7E65FfC80DE234bbB6667aBDd46593D34F0",
+    "decimals": 18
+  },
+  {
+    "chainId": 1,
+    "address": "0xeF4461891DfB3AC8572cCf7C794664A8DD927945",
+    "name": "WalletConnect Token",
+    "symbol": "WCT",
+    "decimals": 18,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/50390/large/wc-token1.png?1727569464"
+  },
+  {
+    "name": "Wrapped Ether",
+    "address": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+    "symbol": "WETH",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
+    "extensions": {
+      "bridgeInfo": {
+        "10": {
+          "tokenAddress": "0x4200000000000000000000000000000000000006"
+        },
+        "137": {
+          "tokenAddress": "0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619"
+        },
+        "42161": {
+          "tokenAddress": "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1"
+        },
+        "42220": {
+          "tokenAddress": "0x2DEf4285787d58a2f811AF24755A8150622f4361"
+        }
+      }
+    }
   },
   {
     "chainId": 1,
@@ -3034,42 +2932,152 @@
   },
   {
     "chainId": 1,
-    "address": "0xb1110919016846972056AB995054D65560D5f05E",
-    "name": "Billions",
-    "symbol": "BILL",
+    "address": "0xdA5e1988097297dCdc1f90D4dFE7909e847CBeF6",
+    "name": "World Liberty Financial",
+    "symbol": "WLFI",
     "decimals": 18,
-    "logoURI": "https://s2.coinmarketcap.com/static/img/coins/64x64/39545.png"
+    "logoURI": "https://coin-images.coingecko.com/coins/images/50767/large/wlfi.png?1756438915"
   },
   {
     "chainId": 1,
-    "address": "0x6055Dc6Ff1077eebe5e6D2BA1a1f53d7Ef8430dE",
-    "name": "Eclipse",
-    "symbol": "ES",
+    "name": "WOO Network",
+    "symbol": "WOO",
+    "logoURI": "https://assets.coingecko.com/coins/images/12921/thumb/w2UiemF__400x400.jpg?1603670367",
+    "address": "0x4691937a7508860F876c9c0a2a617E7d9E945D4B",
+    "decimals": 18
+  },
+  {
+    "chainId": 1,
+    "address": "0xCEDbEA37C8872c4171259Cdfd5255CB8923Cf8e7",
+    "name": "Anoma",
+    "symbol": "XAN",
+    "decimals": 18,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/69380/large/Anoma_Logo_Roundel_RGB_Colour-01.png?1758356672"
+  },
+  {
+    "chainId": 1,
+    "address": "0x68749665FF8D2d112Fa859AA293F07A622782F38",
+    "name": "Tether Gold",
+    "symbol": "XAUT",
     "decimals": 6,
-    "logoURI": "https://coin-images.coingecko.com/coins/images/54958/large/image_%2832%29.png?1742979704"
+    "logoURI": "https://coin-images.coingecko.com/coins/images/10481/large/Tether_Gold.png?1696510471"
   },
   {
     "chainId": 1,
-    "address": "0x9F0C013016E8656bC256f948CD4B79ab25c7b94D",
-    "name": "mETH Protocol",
-    "symbol": "COOK",
-    "decimals": 18,
-    "logoURI": "https://coin-images.coingecko.com/coins/images/50969/large/Logomark-Gradient_Official.png?1729620221"
+    "name": "Chain",
+    "symbol": "XCN",
+    "logoURI": "https://assets.coingecko.com/coins/images/24210/thumb/Chain_icon_200x200.png?1646895054",
+    "address": "0xA2cd3D43c775978A96BdBf12d733D5A1ED94fb18",
+    "decimals": 18
   },
   {
     "chainId": 1,
-    "address": "0xfb072b42907dA2Bf7A8E8cB5dCAa790D45Fd81a8",
-    "name": "Sidekick",
-    "symbol": "K",
-    "decimals": 18,
-    "logoURI": "https://coin-images.coingecko.com/coins/images/67966/large/kick.jpg?1754450296"
+    "address": "0x70e8dE73cE538DA2bEEd35d14187F6959a8ecA96",
+    "name": "XSGD",
+    "symbol": "XSGD",
+    "decimals": 6,
+    "logoURI": "https://assets.coingecko.com/coins/images/12832/standard/StraitsX_Singapore_Dollar_%28XSGD%29_Token_Logo.png?1696512623",
+    "extensions": {
+      "bridgeInfo": {
+        "137": {
+          "tokenAddress": "0xDC3326e71D45186F113a2F448984CA0e8D201995"
+        }
+      }
+    }
   },
   {
     "chainId": 1,
-    "address": "0xB0076DE78Dc50581770BBa1D211dDc0aD4F2a241",
-    "name": "EDGEX",
-    "symbol": "EDGEX",
+    "address": "0x55296f69f40Ea6d20E478533C15A6B08B654E758",
+    "name": "XYO Network",
+    "symbol": "XYO",
     "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/markets/images/11726/large/Logo_White_-_Black_BG.png?1727920571"
+    "logoURI": "https://assets.coingecko.com/coins/images/4519/thumb/XYO_Network-logo.png?1547039819"
+  },
+  {
+    "chainId": 1,
+    "address": "0x01791F726B4103694969820be083196cC7c045fF",
+    "name": "Yield Basis",
+    "symbol": "YB",
+    "decimals": 18,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/54871/large/yieldbasis_400x400.png?1760514173"
+  },
+  {
+    "chainId": 1,
+    "address": "0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e",
+    "name": "yearn finance",
+    "symbol": "YFI",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/11849/thumb/yfi-192x192.png?1598325330"
+  },
+  {
+    "chainId": 1,
+    "address": "0xa1d0E215a23d7030842FC67cE582a6aFa3CCaB83",
+    "name": "DFI money",
+    "symbol": "YFII",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/11902/thumb/YFII-logo.78631676.png?1598677348"
+  },
+  {
+    "chainId": 1,
+    "name": "Yield Guild Games",
+    "symbol": "YGG",
+    "logoURI": "https://assets.coingecko.com/coins/images/17358/thumb/le1nzlO6_400x400.jpg?1632465691",
+    "address": "0x25f8087EAD173b73D6e8B84329989A8eEA16CF73",
+    "decimals": 18
+  },
+  {
+    "chainId": 1,
+    "address": "0xA12CC123ba206d4031D1c7f6223D1C2Ec249f4f3",
+    "name": "Zama",
+    "symbol": "ZAMA",
+    "decimals": 18,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/70921/large/zama.png?1764591992"
+  },
+  {
+    "chainId": 1,
+    "address": "0xf091867EC603A6628eD83D274E835539D82e9cc8",
+    "name": "Zetachain",
+    "symbol": "Zeta",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/26718/standard/Twitter_icon.png?1696525788"
+  },
+  {
+    "chainId": 1,
+    "address": "0x000006c2A22ff4A44ff1f5d0F2ed65F781F55555",
+    "name": "Boundless",
+    "symbol": "ZKC",
+    "decimals": 18,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/68462/large/boundless.png?1755826792"
+  },
+  {
+    "chainId": 1,
+    "address": "0xe1Be424F442D0687129128C6c38aAce44F8c8Dbc",
+    "name": "zkPass",
+    "symbol": "ZKP",
+    "decimals": 18,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/70273/large/zkpass.png?1761379373"
+  },
+  {
+    "chainId": 1,
+    "address": "0x6985884C4392D348587B19cb9eAAf157F13271cd",
+    "name": "LayerZero",
+    "symbol": "ZRO",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/28206/standard/ftxG9_TJ_400x400.jpeg?1696527208",
+    "extensions": {
+      "bridgeInfo": {
+        "42161": {
+          "tokenAddress": "0x6985884C4392D348587B19cb9eAAf157F13271cd"
+        }
+      }
+    }
+  },
+  {
+    "name": "0x Protocol Token",
+    "address": "0xE41d2489571d322189246DaFA5ebDe1F4699F498",
+    "symbol": "ZRX",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xE41d2489571d322189246DaFA5ebDe1F4699F498/logo.png"
   }
 ]


### PR DESCRIPTION
## Summary

This PR adds **MMC Coin** to the Uniswap default token list for Ethereum mainnet.

## Token Details

| Field | Value |
|-------|-------|
| Name | MMC Coin |
| Symbol | MMC |
| Decimals | 18 |
| Chain | Ethereum Mainnet (chainId: 1) |
| Contract | `0x85374E57bFabCcA3613A84456687c8A0C0e0D8A4` |
| Etherscan | https://etherscan.io/token/0x85374E57bFabCcA3613A84456687c8A0C0e0D8A4 |

## About MMC Coin

MMC Coin is the native utility token of **MemeCEX**, the world's first centralized exchange built exclusively for memecoin trading. The platform supports spot trading, token launchpad (IDO), and swap across 8 blockchain networks.

**Utilities:**
- Trading fee discounts (up to 50% for Diamond tier holders)
- Launchpad / IDO access and allocation guarantees
- Holder reward campaigns
- Tier system (Bronze, Silver, Gold, Diamond)
- 25% of platform revenue allocated to monthly $MMC buybacks

## Token Contract

- **Standard:** ERC-20 + LayerZero OFT V2 (multichain ready)
- **Total Supply:** 88,888,888 MMC (fixed, no minting)
- **Features:** Burn mechanism, no mint, no pause, no blacklist
- **Verified on Etherscan:** ✅

## Links

- Website: https://memecex.io
- Twitter: https://x.com/MemeCex_io
- Telegram: https://t.me/MemeCex_io
- Discord: https://discord.gg/MemeCex
- Etherscan: https://etherscan.io/token/0x85374E57bFabCcA3613A84456687c8A0C0e0D8A4
