### PR TITLE
chore: add CODEOWNERS for @Uniswap/consumer-engagement-be

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*   @Uniswap/consumer-engagement-be


### PR DESCRIPTION
## Summary
Add a `.github/CODEOWNERS` file so PRs automatically request review from [@Uniswap/consumer-engagement-be](https://github.com/orgs/Uniswap/teams/consumer-engagement-be).

```
*   @Uniswap/consumer-engagement-be
```

This applies to all paths in the repo.

## Notes
- The team must have **write** access to this repo for CODEOWNERS to work.
- To enforce (block merge until a code owner approves), enable "Require review from Code Owners" in the branch protection rule for `main`.

## Test plan
- [ ] Confirm the team has write access
- [ ] Open a test PR after merge to verify the team is auto-requested