### PR TITLE
feat: add BasedBase (BASW) token to Base chain

### DIFF
--- a/src/tokens/base.json
+++ b/src/tokens/base.json
@@ -613,5 +613,13 @@
     "symbol": "REPPO",
     "decimals": 18,
     "logoURI": "https://coin-images.coingecko.com/coins/images/70797/large/h-rOp1hB_400x400_%281%29.jpg?1763879875"
+  },
+  {
+    "chainId": 8453,
+    "address": "0x8f6286e5ad1ee2a89c31f080ad0db4902a84dade",
+    "name": "Base",
+    "symbol": "BASE",
+    "decimals": 18,
+    "logoURI": "https://cdn.brandfetch.io/id6XsSOVVS/w/400/h/400/theme/dark/icon.jpeg?c=1dxbfHSJFAPEGdCLU4o5B"
   }
 ]


### PR DESCRIPTION
This PR adds the BasedBase (BASW) token to the Base chain (Chain ID: 8453). Token Address: 0x8f6286e5ad1ee2a89c31f080ad0db4902a84dade. Website: https://basw.vercel.app/