### PR TITLE
add: WFLR, FXRP (2026-04-29)

### DIFF
--- a/src/buildList.js
+++ b/src/buildList.js
@@ -23,6 +23,7 @@ const unichain = require("./tokens/unichain.json");
 const xlayer = require("./tokens/xlayer.json");
 const tempo = require("./tokens/tempo.json");
 const monad = require("./tokens/monad.json");
+const flare = require("./tokens/flare.json");
 
 module.exports = async function buildList() {
   const parsed = version.split(".");
@@ -51,6 +52,7 @@ module.exports = async function buildList() {
     ...xlayer,
     ...tempo,
     ...monad,
+    ...flare,
   ]
     // sort them by symbol for easy readability
     .sort((t1, t2) => {

--- a/src/tokens/flare.json
+++ b/src/tokens/flare.json
@@ -1,0 +1,18 @@
+[
+  {
+    "chainId": 14,
+    "address": "0x1D80c49BbBCd1C0911346656B529DF9E5c2F783d",
+    "name": "Wrapped Flare",
+    "symbol": "WFLR",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/28624/large/FLR-icon200x200.png"
+  },
+  {
+    "chainId": 14,
+    "address": "0xAd552A648C74D49E10027AB8a618A3ad4901c5bE",
+    "name": "FXRP",
+    "symbol": "FXRP",
+    "decimals": 6,
+    "logoURI": "https://assets.coingecko.com/coins/images/69731/large/fxrp.png"
+  }
+]


### PR DESCRIPTION
## Summary
Add 2 tokens on Flare (chainId 14) to the default list. This adds Flare as a new chain in the list (`src/tokens/flare.json` + `src/buildList.js` registration).

| Symbol | Chain | Address | Decimals |
|--------|-------|---------|----------|
| WFLR | Flare | `0x1D80c49BbBCd1C0911346656B529DF9E5c2F783d` | 18 |
| FXRP | Flare | `0xAd552A648C74D49E10027AB8a618A3ad4901c5bE` | 6 |

## Verification
- [x] EIP-55 checksums verified
- [x] No duplicate entries
- [x] `yarn test` passes
- [x] Onchain symbol/decimals confirmed via Flare RPC

## Related
Closes #2459