### PR TITLE
chore: bump version to 20.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uniswap/default-token-list",
-  "version": "20.2.0",
+  "version": "20.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@uniswap/default-token-list",
-      "version": "20.2.0",
+      "version": "20.3.0",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "@ethersproject/address": "^5.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/default-token-list",
-  "version": "20.2.0",
+  "version": "20.3.0",
   "description": "The Uniswap default token list",
   "main": "build/uniswap-default.tokenlist.json",
   "scripts": {


### PR DESCRIPTION
## Summary
Bump version to 20.3.0 to capture recently merged token additions.