### PR TITLE
Add PEDULI token on Polygon

### DIFF
--- a/src/tokens/polygon.json
+++ b/src/tokens/polygon.json
@@ -334,5 +334,13 @@
     "symbol": "XAUt0",
     "decimals": 6,
     "logoURI": "https://coin-images.coingecko.com/coins/images/66560/large/XAUt0_Token_Icon_Gold.png?1749747942"
-  }
+  },
+  {
+  "chainId": 137,
+  "address": "0xaE9aBF1090EB04E1b6E83851013C3d8f1189D8C9",
+  "name": "PEDULI",
+  "symbol": "PEDULI",
+  "decimals": 18,
+  "logoURI": "https://peduli.app/logo.svg"
+}
 ]


### PR DESCRIPTION
Token name: PEDULI
Symbol: PEDULI
Contract: 0xaE9aBF1090EB04E1b6E83851013C3d8f1189D8C9
Network: Polygon (chainId: 137)
Decimals: 18
Website: https://peduli.app
Logo: https://peduli.app/logo.svg

Description:
PEDULI is a legitimate ERC-20 utility reward token by WargaTerra Enterprise. 
Users earn PEDULI tokens by completing physical exercises tracked via AI pose 
detection on the PEDULI app (https://peduli.app). The token is deployed via 
Thirdweb's audited ERC-20 infrastructure with no transfer restrictions, 
blacklists, or pause mechanisms. All transfers are transparent and verifiable 
on PolygonScan.

Listed on GeckoTerminal:
https://www.geckoterminal.com/polygon_pos/pools/0x02ef23fd95cb61a1a5e21d63e4eead4b99a766996ca4f96a6b5f018efba945f4

PolygonScan:
https://polygonscan.com/token/0xaE9aBF1090EB04E1b6E83851013C3d8f1189D8C9

Contact: hello@peduli.app
Founder: https://www.linkedin.com/in/fauzanbaharudin