### PR TITLE
Add Zaro Coin (ZARO) — Ethereum + BNB Chain

### DIFF
--- a/src/tokens/base.json
+++ b/src/tokens/base.json
@@ -668,5 +668,23 @@
     "symbol": "CBMEGA",
     "decimals": 18,
     "logoURI": "https://coin-images.coingecko.com/coins/images/102173020/large/megaeth.png?1777256235"
+  },
+  {
+    "chainId": 8453,
+    "address": "0x1d4CeA73e212829d06B9a774d2e06be9DEe5AAB0",
+    "name": "Zaro Coin",
+    "symbol": "ZARO",
+    "decimals": 18,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/68493/large/ZARO_logo_2D.png?1755934268",
+    "extensions": {
+      "bridgeInfo": {
+        "1": {
+          "tokenAddress": "0xc311FD6DA9686507F33991543d8158EF5FaDd5E7"
+        },
+        "56": {
+          "tokenAddress": "0xa9D72F6C1490647DF20E8Fad3C136cA6AC42c2fc"
+        }
+      }
+    }
   }
 ]

--- a/src/tokens/bnb.json
+++ b/src/tokens/bnb.json
@@ -94,5 +94,20 @@
     "symbol": "XAUt0",
     "decimals": 6,
     "logoURI": "https://coin-images.coingecko.com/coins/images/66560/large/XAUt0_Token_Icon_Gold.png?1749747942"
+  },
+  {
+    "chainId": 56,
+    "address": "0xa9D72F6C1490647DF20E8Fad3C136cA6AC42c2fc",
+    "name": "Zaro Coin",
+    "symbol": "ZARO",
+    "decimals": 18,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/68493/large/ZARO_logo_2D.png?1755934268",
+    "extensions": {
+      "bridgeInfo": {
+        "1": {
+          "tokenAddress": "0xc311FD6DA9686507F33991543d8158EF5FaDd5E7"
+        }
+      }
+    }
   }
 ]

--- a/src/tokens/bnb.json
+++ b/src/tokens/bnb.json
@@ -106,8 +106,12 @@
       "bridgeInfo": {
         "1": {
           "tokenAddress": "0xc311FD6DA9686507F33991543d8158EF5FaDd5E7"
+        },
+        "8453": {
+          "tokenAddress": "0x1d4CeA73e212829d06B9a774d2e06be9DEe5AAB0"
         }
       }
     }
   }
 ]
+

--- a/src/tokens/mainnet.json
+++ b/src/tokens/mainnet.json
@@ -3199,5 +3199,20 @@
     "symbol": "EV",
     "decimals": 18,
     "logoURI": "https://coin-images.coingecko.com/coins/images/71690/large/EV_token_v2_White.png?1773933783"
+  },
+  {
+    "name": "Zaro Coin",
+    "address": "0xc311FD6DA9686507F33991543d8158EF5FaDd5E7",
+    "symbol": "ZARO",
+    "decimals": 18,
+    "chainId": 1,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/68493/large/ZARO_logo_2D.png?1755934268",
+    "extensions": {
+      "bridgeInfo": {
+        "56": {
+          "tokenAddress": "0xa9D72F6C1490647DF20E8Fad3C136cA6AC42c2fc"
+        }
+      }
+    }
   }
 ]

--- a/src/tokens/mainnet.json
+++ b/src/tokens/mainnet.json
@@ -3211,6 +3211,9 @@
       "bridgeInfo": {
         "56": {
           "tokenAddress": "0xa9D72F6C1490647DF20E8Fad3C136cA6AC42c2fc"
+        },
+        "8453": {
+          "tokenAddress": "0x1d4CeA73e212829d06B9a774d2e06be9DEe5AAB0"
         }
       }
     }


### PR DESCRIPTION
Adds **Zaro Coin (ZARO)** to `mainnet.json` and `bnb.json` with bidirectional `extensions.bridgeInfo` cross-references.

## Token

| Field | Value |
|---|---|
| Name | Zaro Coin |
| Symbol | ZARO |
| Decimals | 18 |
| Ethereum contract | [`0xc311FD6DA9686507F33991543d8158EF5FaDd5E7`](https://etherscan.io/token/0xc311FD6DA9686507F33991543d8158EF5FaDd5E7) |
| BNB Chain contract | [`0xa9D72F6C1490647DF20E8Fad3C136cA6AC42c2fc`](https://bscscan.com/token/0xa9D72F6C1490647DF20E8Fad3C136cA6AC42c2fc) |
| Logo | https://coin-images.coingecko.com/coins/images/68493/large/ZARO_logo_2D.png (hosted by CoinGecko) |

## Why this should be on the default list

- **Contract is renounced** (ownership transferred to zero address, June 30, 2025). No mint, no pause, no blacklist, no parameter changes possible by any party.
- **Liquidity locked 255 years at UNCX**: [lock tx](https://etherscan.io/tx/0xbb17a0d05a167047fb478c9769badaed00fa40e964a54d2917181420d26f4581). Project cannot withdraw or modify.
- **Total supply mathematically fixed at 1,000,000,000** by the renounced contract.
- **Audited template**: built on Thirdweb's [audited TokenERC20](https://github.com/thirdweb-dev/contracts/blob/main/audit-reports/audit-12.pdf) implementation (OpenZeppelin-based).
- **Independent BVI legal opinion** published, analyzing ZARO under six international regulatory frameworks: [link](https://github.com/zarocoin/zarocoin/blob/main/docs/legal/ZARO%20Coin%20BVI%20Legal%20Opinion%20Public%20-%20Short.pdf).
- **Public chronological transparency record** at https://www.zarocoin.xyz/history, including on-chain receipts for every operating event.
- **No presale, no team allocation, no VC round.** The founder purchased OTC at the same public Uniswap price as any other buyer (verifiable on-chain).
- **Public security tooling clean**: [GoPlus](https://gopluslabs.io/token-security/1/0xc311FD6DA9686507F33991543d8158EF5FaDd5E7), [Honeypot.is](https://honeypot.is/ethereum?address=0xc311FD6DA9686507F33991543d8158EF5FaDd5E7).

## Listings already in place

- CoinGecko: https://www.coingecko.com/en/coins/zaro-coin
- CoinMarketCap: https://coinmarketcap.com/currencies/zaro-coin/
- DexScreener: https://dexscreener.com/ethereum/0x53085839a2ee860e58108665825fc7ef5e061213
- GeckoTerminal: https://www.geckoterminal.com/eth/pools/0x53085839a2ee860e58108665825fc7ef5e061213

## Issuing entity

ZaroVerse Ltd, British Virgin Islands (Company Number 2183451). Founder publicly identified, contactable, and accountable. Project site: https://www.zarocoin.xyz. Transparency repo: https://github.com/zarocoin/zarocoin.

## Bridge

Wormhole bridge between Ethereum (canonical) and BNB Chain. 1:1 backed by ZARO locked on Ethereum.