### PR TITLE
add: KORPO (2026-05-14)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uniswap/default-token-list",
-  "version": "20.6.0",
+  "version": "20.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@uniswap/default-token-list",
-      "version": "20.6.0",
+      "version": "20.7.0",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "@ethersproject/address": "^5.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/default-token-list",
-  "version": "20.6.0",
+  "version": "20.7.0",
   "description": "The Uniswap default token list",
   "main": "build/uniswap-default.tokenlist.json",
   "scripts": {

--- a/src/tokens/base.json
+++ b/src/tokens/base.json
@@ -668,5 +668,13 @@
     "symbol": "CBMEGA",
     "decimals": 18,
     "logoURI": "https://coin-images.coingecko.com/coins/images/102173020/large/megaeth.png?1777256235"
+  },
+  {
+    "chainId": 8453,
+    "address": "0xF970c93D00De94786F6fdABBc63180da1D981bc7",
+    "name": "KORPO",
+    "symbol": "KORPO",
+    "decimals": 18,
+    "logoURI": "https://korpo.pro/assets/korpo-logo-256.png"
   }
 ]


### PR DESCRIPTION
## Summary
Add KORPO token to the Base default list.

| Symbol | Chain | Address | Decimals |
|--------|-------|---------|----------|
| KORPO | Base | `0xF970c93D00De94786F6fdABBc63180da1D981bc7` | 18 |

## Token Information
- **Name**: KORPO (Universal Basic Income)
- **Symbol**: KORPO
- **Decimals**: 18
- **Chain**: Base (chainId: 8453)
- **Contract**: [0xF970c93D00De94786F6fdABBc63180da1D981bc7](https://basescan.org/address/0xF970c93D00De94786F6fdabbc63180da1d981bc7)
- **Website**: [korpo.pro](https://korpo.pro)
- **Logo**: [korpo-logo-256.png](https://korpo.pro/assets/korpo-logo-256.png)

## Tokenomics
- **Total Supply**: 300 KORPO (fixed, no mint function)
- **Daily Claim**: 100 KORPO per eligible wallet (permissionless)
- **Burn Mechanism**: 0.5% of every transfer permanently burned
- **Uniswap V3 Pool**: [0x588Cc334d86C40fF16b8714f1Ff8bd25993CFa9e](https://basescan.org/address/0x588Cc334d86C40fF16b8714f1Ff8bd25993CFa9e) (1% fee)

## Verification
- [x] EIP-55 checksums verified
- [x] No duplicate entry (same chainId + address)
- [x] Required fields present (chainId, address, name, symbol, decimals)
- [x] Logo URI publicly accessible
- [x] Contract deployed on Base