### PR TITLE
Add Arena Two (ATWO) on Base

### DIFF
--- a/src/tokens/base.json
+++ b/src/tokens/base.json
@@ -668,5 +668,13 @@
     "symbol": "CBMEGA",
     "decimals": 18,
     "logoURI": "https://coin-images.coingecko.com/coins/images/102173020/large/megaeth.png?1777256235"
+  },
+  {
+    "chainId": 8453,
+    "address": "0x499D35eBE6cEe9B2Ac35Fd003fcBbeeB9CFc7B32",
+    "name": "Arena Two",
+    "symbol": "ATWO",
+    "decimals": 18,
+    "logoURI": "https://arenatwo.com/token/atwo/logo-200.png"
   }
 ]


### PR DESCRIPTION
## Summary

Adds **Arena Two ($ATWO)** to the Base entries in `src/tokens/base.json`.

- **Contract:** `0x499D35eBE6cEe9B2Ac35Fd003fcBbeeB9CFc7B32` (Base, chain ID 8453)
- **Symbol:** ATWO
- **Decimals:** 18
- **Logo:** `https://arenatwo.com/token/atwo/logo-200.png` (200×200 transparent PNG)

## Token information

Arena Two is a multi-sport entertainment platform on Base running a live World Series across eight global cities (6v6 indoor football, MMA, padel). The native ATWO token is used for on-chain fan voting that influences live competitive outcomes, plus access to player trials, digital collectible drops, and token-gated event experiences.

## Verification

- **Contract on BaseScan (verified source):** https://basescan.org/token/0x499D35eBE6cEe9B2Ac35Fd003fcBbeeB9CFc7B32
- **CoinGecko:** https://www.coingecko.com/en/coins/arena-two
- **CoinMarketCap:** UCID 40006 — https://coinmarketcap.com/currencies/arena-two/
- **Audit:** Hacken, December 2025, 0 Critical / 0 High — https://hacken.io/audits/arena-two/
- **Source repo:** https://github.com/arenatwo/smart-contracts

## TGE / listing context

TGE is 18 May 2026 at 12:00 UTC with simultaneous listings on OKX (X Launch), KuCoin, MEXC, BingX, Bitpanda, BTSE, Bitmart, Blofin, and Aerodrome (Base DEX).

## Files

- `src/tokens/base.json` — single entry appended (84 → 85)