### PR TITLE
fix(workflows): randomize $GITHUB_OUTPUT heredoc delimiter in _claude-task-worker

### DIFF
--- a/.github/workflows/_claude-task-worker.yml
+++ b/.github/workflows/_claude-task-worker.yml
@@ -424,7 +424,14 @@ jobs:
           # delimiter so an attacker-controlled INPUT_ISSUE_DESCRIPTION cannot
           # terminate the heredoc and inject a replacement `prompt<<...` entry
           # (last-write-wins on duplicate keys per the $GITHUB_OUTPUT spec).
-          PROMPT_DELIM="PROMPT_DELIMITER_$(date +%s%N)_$(openssl rand -hex 16)"
+          # Fail fast if openssl returns empty (would otherwise silently
+          # degrade the delimiter to a predictable prefix+timestamp), and
+          # refuse to write a body that exceeds the $GITHUB_OUTPUT 1MB
+          # per-value cap (truncation would leave an unclosed heredoc).
+          PROMPT_DELIM_RAND=$(openssl rand -hex 16)
+          [ -n "$PROMPT_DELIM_RAND" ] || { echo "::error::openssl rand returned empty; refusing to write predictable delimiter" >&2; exit 1; }
+          [ "$(printf '%s' "$PROMPT" | wc -c)" -lt 900000 ] || { echo "::error::prompt body exceeds 900KB; would risk \$GITHUB_OUTPUT truncation" >&2; exit 1; }
+          PROMPT_DELIM="PROMPT_DELIMITER_$(date +%s%N)_${PROMPT_DELIM_RAND}"
           echo "prompt<<${PROMPT_DELIM}" >> "$GITHUB_OUTPUT"
           echo "$PROMPT" >> "$GITHUB_OUTPUT"
           echo "${PROMPT_DELIM}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/_claude-task-worker.yml
+++ b/.github/workflows/_claude-task-worker.yml
@@ -420,10 +420,14 @@ jobs:
           PROMPT_EOF
           )
 
-          # Escape for GitHub Actions output
-          echo "prompt<<PROMPT_DELIM" >> $GITHUB_OUTPUT
-          echo "$PROMPT" >> $GITHUB_OUTPUT
-          echo "PROMPT_DELIM" >> $GITHUB_OUTPUT
+          # Escape for GitHub Actions output. Use a per-call unguessable
+          # delimiter so an attacker-controlled INPUT_ISSUE_DESCRIPTION cannot
+          # terminate the heredoc and inject a replacement `prompt<<...` entry
+          # (last-write-wins on duplicate keys per the $GITHUB_OUTPUT spec).
+          PROMPT_DELIM="PROMPT_DELIMITER_$(date +%s%N)_$(openssl rand -hex 16)"
+          echo "prompt<<${PROMPT_DELIM}" >> "$GITHUB_OUTPUT"
+          echo "$PROMPT" >> "$GITHUB_OUTPUT"
+          echo "${PROMPT_DELIM}" >> "$GITHUB_OUTPUT"
 
       # Build MCP config with Linear token passed via env var (avoids expression injection)
       - name: Build MCP config


### PR DESCRIPTION
## Summary

The `Build prompt` step in `_claude-task-worker.yml` writes the LLM prompt to `$GITHUB_OUTPUT` using the static literal `PROMPT_DELIM` as the heredoc terminator. Because the prompt body contains `$INPUT_ISSUE_DESCRIPTION` — labeled "untrusted user input" by the workflow's own in-prompt safety paragraph — a Linear ticket containing a bare `PROMPT_DELIM` line can terminate the heredoc and inject a `prompt<<EVIL` block that overwrites the value `claude-code-action` consumes.

Replace the static delimiter with a per-call value composed of `date +%s%N` plus 128 bits of `openssl rand` CSPRNG output. An attacker cannot match a delimiter they do not know.

This is the same pattern already shipped in `Uniswap/ai-toolkit/.github/scripts/build-prompt.ts:generateUniqueDelimiter` ("to prevent injection attacks", commit `7159a4f`). The TypeScript helper covers prompts built by that script; this patch extends the same defense to the YAML worker.

**Plus** two hardenings flagged by adversarial review of the initial fix:

1. **openssl-rand failsafe.** `bash -e` does not abort on a failing command substitution inside a variable assignment. If `openssl` returns empty (Ubuntu image regression, `/dev/urandom` hiccup, missing binary), `PROMPT_DELIM` silently degrades to a predictable prefix+timestamp string. Assert non-empty before use; `exit 1` with an `::error::` annotation if empty.

2. **`$GITHUB_OUTPUT` 1MB per-value size guard.** A >1MB attacker payload would cause silent mid-line truncation of the heredoc body; the closing delimiter then never gets written and the parser either fails or parses subsequent step outputs as prompt continuation. Refuse to write values > 900KB (conservative cap below the 1MB limit) with an `::error::` annotation.

## What changed

`.github/workflows/_claude-task-worker.yml` lines ~423–436. Two commits:
1. Random delimiter (+8/−4)
2. openssl failsafe + size guard (+8/−1)

```yaml
PROMPT_DELIM_RAND=$(openssl rand -hex 16)
[ -n "$PROMPT_DELIM_RAND" ] || { echo "::error::openssl rand returned empty; refusing to write predictable delimiter" >&2; exit 1; }
[ "$(printf '%s' "$PROMPT" | wc -c)" -lt 900000 ] || { echo "::error::prompt body exceeds 900KB; would risk \$GITHUB_OUTPUT truncation" >&2; exit 1; }
PROMPT_DELIM="PROMPT_DELIMITER_$(date +%s%N)_${PROMPT_DELIM_RAND}"
echo "prompt<<${PROMPT_DELIM}" >> "$GITHUB_OUTPUT"
echo "$PROMPT" >> "$GITHUB_OUTPUT"
echo "${PROMPT_DELIM}" >> "$GITHUB_OUTPUT"
```

The patch is intentionally surgical — no refactor of `Build prompt`, no changes to `envsubst` arguments, no changes to allowed-tools or the validation steps that run after the Claude session.

## Test plan

Local pressure tests (`/tmp/pressure_test_v2.sh`, 8 hardened-pattern assertions, all passing):

- ✅ **Attacker injection contained** — patched code produces a single `prompt` output containing both the legitimate body (with "Untrusted Input" warning) and the attacker text embedded as ordinary content. Structural bypass is gone.
- ✅ **Benign body round-trips** — normal description preserved.
- ✅ **Delimiter uniqueness** — two consecutive runs produce distinct delimiters.
- ✅ **openssl-empty abort** — simulated via PATH override; step exits non-zero with `::error::` annotation, zero bytes written to `$GITHUB_OUTPUT`.
- ✅ **Oversize abort** — 900001-byte body; step exits non-zero, zero bytes written.
- ✅ **Just-under-cap success** — 899999-byte body writes successfully.

To verify post-merge: trigger a scheduled or `workflow_dispatch` run, inspect the `Build prompt` step log, and confirm the `prompt:` input reaching `claude-code-action` matches the full assembled prompt.

## Session context

**Investigation.** Discovered through the bug bounty program. The vulnerability class — heredoc termination in `$GITHUB_OUTPUT` via duplicate-key last-write-wins — is documented by the GitHub Actions multiline-string format spec and has been reported against other organizations' workflows historically. The exploitable instance here was created in PR #2407 (2026-04-06); the fix had already been written in `ai-toolkit/build-prompt.ts` three and a half months earlier but was never propagated to the YAML files in either repo.

**Options evaluated.**
- *Random delimiter + RNG-failsafe + size guard (chosen).* Minimum-touch fix, ~16 total lines across two commits, structurally immune. Mirrors the existing ai-toolkit TypeScript helper.
- *Input sanitation only (rejected).* Filter ticket descriptions whose body contains a line matching `^PROMPT_DELIM\s*$`. Brittle — the delimiter pattern is part of the workflow file, so any future delimiter rename would silently break the filter. Useful only as belt-and-braces; not a sound primary defense.
- *Migrate to `claude-code-action`'s `prompt-file` input (deferred).* `ai-toolkit/_claude-code-review.yml` and `_generate-pr-metadata.yml` already use this pattern — write the prompt to `/tmp/final-prompt.txt`, export only the file path through `$GITHUB_OUTPUT`. Structurally immune by design. Larger refactor; out of scope here, worth doing later as the long-term shape.

**Adversarial review.** Ran an adversarial review of the initial random-delimiter patch via a security-analyzer subagent and an independent code-reviewer subagent. The two hardenings above came from that review. The reviewers confirmed the random delimiter is structurally sound — `openssl rand -hex 16` gives 128 bits of CSPRNG entropy, parser does exact line equality (so format-guess attacks fail), no leakage path, no race conditions. The failure modes addressed by this PR are the only structural gaps they found.

**Out-of-scope hardening worth doing separately.** Adversarial review surfaced four broader issues that the PROMPT_DELIM fix doesn't and can't address; recommend filing separately:
- `dtl/_claude-task-worker.yml:481-483` allowlist permits `package.json`/`package-lock.json` — prompt-injected Claude could add a malicious dependency. The `npm view ... && skip` guard in `deploy.yaml` is bypassed by a `npm version` bump.
- Residual Path B (Linear-comment credential exfil) — fix closes structural injection but the LLM still has `mcp__linear__linear_add_comment` plus `Read`-tool access to the GitHub App token file and the Anthropic key.
- `bullfrog: egress-policy: audit` — converting to `block` with an explicit allowlist would contain the next prompt-control bug.
- `inputs.toolkit_ref` is unvalidated in the called actions.

**Constraints.** GitHub-hosted Ubuntu runners have `openssl` and GNU `date` (with `%N` nanosecond support). No new dependencies. The build-prompt step does not have `set -x`, so the delimiter does not leak via step logs — and even if it did, leakage is per-run and useful only for the run that already executed.

## Related

Mirror PR in `Uniswap/ai-toolkit`: https://github.com/Uniswap/ai-toolkit/pull/509 — covers 10 workflow/action files (the same exploitable class in `_claude-task-worker.yml`, plus 9 other sites with the same anti-pattern including one separate caller-controlled-prompt-file site in `_generate-changelog.yml:172` that's the same Cantina class).