### PR TITLE
Add x402 Agentic token to base.json

### DIFF
--- a/src/tokens/base.json
+++ b/src/tokens/base.json
@@ -668,5 +668,14 @@
     "symbol": "CBMEGA",
     "decimals": 18,
     "logoURI": "https://coin-images.coingecko.com/coins/images/102173020/large/megaeth.png?1777256235"
+  },
+  {
+  "chainId": 8453,
+  "name": "x402 Agentic",
+  "symbol": "X402",
+  "decimals": 18,
+  "address": "0xcab815d8a171091a8647f126e0fb7c009946b162",
+  "logoURI": "https://basescan.org/token/images/x402agentic_x402_64.png",
+  "tags": ["base"]
   }
 ]


### PR DESCRIPTION
## Summary
Adding x402 Agentic token to Uniswap default token list.

## Token Details
- **Name:** x402 Agentic
- **Symbol:** X402
- **Decimals:** 18
- **Chain:** Base (8453)
- **Contract:** 0xcab815d8a171091a8647f126e0fb7c009946b162

## Verification
- BaseScan: https://basescan.org/token/0xcab815d8a171091a8647f126e0fb7c009946b162
- Project: https://x402agentic.ai

## Why This Matters
Token was recently rebranded and needs to be added to the official list  so Uniswap displays correct metadata across all interfaces.## Summary Adding x402 Agentic token to Uniswap default token list.