### PR TITLE
Add Anisian (ANI) – Base

### DIFF
--- a/src/tokens/base.json
+++ b/src/tokens/base.json
@@ -668,5 +668,13 @@
     "symbol": "CBMEGA",
     "decimals": 18,
     "logoURI": "https://coin-images.coingecko.com/coins/images/102173020/large/megaeth.png?1777256235"
+  },
+  {
+    "chainId": 8453,
+    "address": "0xE378841a3970FD43ac8aD4D1D77b068C87287e5f",
+    "name": "Anisian",
+    "symbol": "ANI",
+    "decimals": 18,
+    "logoURI": "https://raw.githubusercontent.com/anisiananifree/anisian_contracts/main/ipfs/ani-logo-256.png"
   }
 ]


### PR DESCRIPTION
## Add Anisian (ANI) on Base

- **Token:** Anisian (`ANI`), 18 decimals
- **Chain:** Base mainnet (chainId `8453`)
- **Contract:** `0xE378841a3970FD43ac8aD4D1D77b068C87287e5f`
  ([verified on Basescan](https://basescan.org/token/0xE378841a3970FD43ac8aD4D1D77b068C87287e5f#code))
- **Liquidity:** Aerodrome pool `0x2F947691C97244D845B2db2f86489D21c4c919bD`
- **Source / metadata / docs:** https://github.com/anisiananifree/anisian_contracts (MIT-licensed)
- **Logo:** 256×256 PNG hosted in the source repo

### About

Anisian is a **fixed-supply, immutable** ERC-20 on Base with a deflationary halving burn schedule:

- 100,000,000 ANI minted once at deployment. No further minting.
- ~79,000,000 ANI scheduled to be burned over ~14 years via a **permissionless** burn vault (`triggerBurn()` callable by anyone).
- **No owner, no admin, no mint, no pause, no upgrade.** The deployer has no special on-chain powers after `initialize()`.

This PR only adds the token entry; no scripts, lockfiles, or unrelated files are modified.
