### PR TITLE
add: AUSD (2026-06-02)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uniswap/default-token-list",
-  "version": "21.1.0",
+  "version": "21.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@uniswap/default-token-list",
-      "version": "21.1.0",
+      "version": "21.2.0",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "@ethersproject/address": "^5.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/default-token-list",
-  "version": "21.1.0",
+  "version": "21.2.0",
   "description": "The Uniswap default token list",
   "main": "build/uniswap-default.tokenlist.json",
   "scripts": {

--- a/src/tokens/arbitrum.json
+++ b/src/tokens/arbitrum.json
@@ -110,5 +110,13 @@
     "symbol": "XAUt0",
     "decimals": 6,
     "logoURI": "https://coin-images.coingecko.com/coins/images/66560/large/XAUt0_Token_Icon_Gold.png?1749747942"
+  },
+  {
+    "chainId": 42161,
+    "address": "0x00000000eFE302BEAA2b3e6e1b18d08D69a9012a",
+    "name": "AUSD",
+    "symbol": "AUSD",
+    "decimals": 6,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/39284/large/AUSD_1024px.png?1764684132"
   }
 ]

--- a/src/tokens/avalanche.json
+++ b/src/tokens/avalanche.json
@@ -86,5 +86,13 @@
     "symbol": "XAUt0",
     "decimals": 6,
     "logoURI": "https://coin-images.coingecko.com/coins/images/66560/large/XAUt0_Token_Icon_Gold.png?1749747942"
+  },
+  {
+    "chainId": 43114,
+    "address": "0x00000000eFE302BEAA2b3e6e1b18d08D69a9012a",
+    "name": "AUSD",
+    "symbol": "AUSD",
+    "decimals": 6,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/39284/large/AUSD_1024px.png?1764684132"
   }
 ]

--- a/src/tokens/base.json
+++ b/src/tokens/base.json
@@ -668,5 +668,13 @@
     "symbol": "CBMEGA",
     "decimals": 18,
     "logoURI": "https://coin-images.coingecko.com/coins/images/102173020/large/megaeth.png?1777256235"
+  },
+  {
+    "chainId": 8453,
+    "address": "0x00000000eFE302BEAA2b3e6e1b18d08D69a9012a",
+    "name": "AUSD",
+    "symbol": "AUSD",
+    "decimals": 6,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/39284/large/AUSD_1024px.png?1764684132"
   }
 ]

--- a/src/tokens/bnb.json
+++ b/src/tokens/bnb.json
@@ -110,5 +110,13 @@
     "symbol": "GENIUS",
     "decimals": 18,
     "logoURI": "https://coin-images.coingecko.com/coins/images/71660/large/genius.png?1768804210"
+  },
+  {
+    "chainId": 56,
+    "address": "0x00000000eFE302BEAA2b3e6e1b18d08D69a9012a",
+    "name": "AUSD",
+    "symbol": "AUSD",
+    "decimals": 6,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/39284/large/AUSD_1024px.png?1764684132"
   }
 ]

--- a/src/tokens/mainnet.json
+++ b/src/tokens/mainnet.json
@@ -3214,5 +3214,13 @@
     "symbol": "USDR",
     "decimals": 6,
     "logoURI": "https://coin-images.coingecko.com/coins/images/53721/large/stablrusd-logo.png?1737126629"
- }
+  },
+  {
+    "chainId": 1,
+    "address": "0x00000000eFE302BEAA2b3e6e1b18d08D69a9012a",
+    "name": "AUSD",
+    "symbol": "AUSD",
+    "decimals": 6,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/39284/large/AUSD_1024px.png?1764684132"
+  }
 ]

--- a/src/tokens/polygon.json
+++ b/src/tokens/polygon.json
@@ -334,5 +334,13 @@
     "symbol": "XAUt0",
     "decimals": 6,
     "logoURI": "https://coin-images.coingecko.com/coins/images/66560/large/XAUt0_Token_Icon_Gold.png?1749747942"
+  },
+  {
+    "chainId": 137,
+    "address": "0x00000000eFE302BEAA2b3e6e1b18d08D69a9012a",
+    "name": "AUSD",
+    "symbol": "AUSD",
+    "decimals": 6,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/39284/large/AUSD_1024px.png?1764684132"
   }
 ]

--- a/src/tokens/solana.json
+++ b/src/tokens/solana.json
@@ -1422,5 +1422,13 @@
     "symbol": "META",
     "decimals": 6,
     "logoURI": "https://coin-images.coingecko.com/coins/images/68320/large/META.png?1755335883"
+  },
+  {
+    "chainId": 501000101,
+    "address": "AUSD1jCcCyPLybk1YnvPWsHQSrZ46dxwoMniN4N2UEB9",
+    "name": "AUSD",
+    "symbol": "AUSD",
+    "decimals": 6,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/39284/large/AUSD_1024px.png?1764684132"
   }
 ]


### PR DESCRIPTION
## Summary
Add AUSD (Agora US Dollar) to the default list across 7 chains.

| Symbol | Chain | Address | Decimals |
|--------|-------|---------|----------|
| AUSD | Ethereum | `0x00000000eFE302BEAA2b3e6e1b18d08D69a9012a` | 6 |
| AUSD | Arbitrum | `0x00000000eFE302BEAA2b3e6e1b18d08D69a9012a` | 6 |
| AUSD | Avalanche | `0x00000000eFE302BEAA2b3e6e1b18d08D69a9012a` | 6 |
| AUSD | Base | `0x00000000eFE302BEAA2b3e6e1b18d08D69a9012a` | 6 |
| AUSD | BNB | `0x00000000eFE302BEAA2b3e6e1b18d08D69a9012a` | 6 |
| AUSD | Polygon | `0x00000000eFE302BEAA2b3e6e1b18d08D69a9012a` | 6 |
| AUSD | Solana | `AUSD1jCcCyPLybk1YnvPWsHQSrZ46dxwoMniN4N2UEB9` | 6 |

Note: The Linear ticket also requested Monad, which is not currently a supported chain in this token list. AUSD on Monad was not added.

## Verification
- [x] EIP-55 checksums verified
- [x] No duplicate entries
- [x] `yarn test` passes

## Linear tickets
- [CONS-2254](https://linear.app/uniswap/issue/CONS-2254/default-token-list-addition-ausd)