### PR TITLE
add: O, SLX (2026-06-04)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uniswap/default-token-list",
-  "version": "21.2.0",
+  "version": "21.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@uniswap/default-token-list",
-      "version": "21.2.0",
+      "version": "21.3.0",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "@ethersproject/address": "^5.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/default-token-list",
-  "version": "21.2.0",
+  "version": "21.3.0",
   "description": "The Uniswap default token list",
   "main": "build/uniswap-default.tokenlist.json",
   "scripts": {

--- a/src/tokens/base.json
+++ b/src/tokens/base.json
@@ -676,5 +676,12 @@
     "symbol": "AUSD",
     "decimals": 6,
     "logoURI": "https://coin-images.coingecko.com/coins/images/39284/large/AUSD_1024px.png?1764684132"
+  },
+  {
+    "chainId": 8453,
+    "address": "0x182FA643E5f29d5EcA75e7b9CF9336A3fe4620b2",
+    "name": "o1.exchange",
+    "symbol": "O",
+    "decimals": 18
   }
 ]

--- a/src/tokens/solana.json
+++ b/src/tokens/solana.json
@@ -1430,5 +1430,13 @@
     "symbol": "AUSD",
     "decimals": 6,
     "logoURI": "https://coin-images.coingecko.com/coins/images/39284/large/AUSD_1024px.png?1764684132"
+  },
+  {
+    "chainId": 501000101,
+    "address": "SLXdx4BUt2v9uJQNzWqSfzTJ9UKLUDsvxHFMEEdrfgq",
+    "name": "Solstice",
+    "symbol": "SLX",
+    "decimals": 6,
+    "logoURI": "https://assets.coingecko.com/coins/images/71128/standard/slx.png?1779455873"
   }
 ]


### PR DESCRIPTION
## Summary
Add 2 tokens to the default list.

| Symbol | Chain | Address | Decimals |
|--------|-------|---------|----------|
| O | Base | `0x182FA643E5f29d5EcA75e7b9CF9336A3fe4620b2` | 18 |
| SLX | Solana | `SLXdx4BUt2v9uJQNzWqSfzTJ9UKLUDsvxHFMEEdrfgq` | 6 |

Note: The o1.exchange (O) ticket did not include a logoURI ("Unknown at this time"), so the entry is added without one. It can be updated later when the logo is available.

## Verification
- [x] EIP-55 checksums verified
- [x] No duplicate entries
- [x] `yarn test` passes

## Linear tickets
- [CONS-2211](https://linear.app/uniswap/issue/CONS-2211/default-token-list-addition-o1exchange)
- [CONS-2212](https://linear.app/uniswap/issue/CONS-2212/default-token-list-addition-solstice)