### PR TITLE
add: RE, ARX (2026-06-11)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uniswap/default-token-list",
-  "version": "22.0.0",
+  "version": "22.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@uniswap/default-token-list",
-      "version": "22.0.0",
+      "version": "22.1.0",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "@ethersproject/address": "^5.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/default-token-list",
-  "version": "22.0.0",
+  "version": "22.1.0",
   "description": "The Uniswap default token list",
   "main": "build/uniswap-default.tokenlist.json",
   "scripts": {

--- a/src/tokens/mainnet.json
+++ b/src/tokens/mainnet.json
@@ -3222,5 +3222,13 @@
     "symbol": "AUSD",
     "decimals": 6,
     "logoURI": "https://coin-images.coingecko.com/coins/images/39284/large/AUSD_1024px.png?1764684132"
+  },
+  {
+    "chainId": 1,
+    "address": "0x526526528F35AC738177003b8773B402B8Df8143",
+    "name": "RE",
+    "symbol": "RE",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/102173708/standard/RE-Token.png?1781031591"
   }
 ]

--- a/src/tokens/solana.json
+++ b/src/tokens/solana.json
@@ -1438,5 +1438,13 @@
     "symbol": "SLX",
     "decimals": 6,
     "logoURI": "https://assets.coingecko.com/coins/images/71128/standard/slx.png?1779455873"
+  },
+  {
+    "chainId": 501000101,
+    "address": "ARXwZkNAtzPfdcoqQiduJn8EPv9fKiDfGn2KyggyDrFs",
+    "name": "Arcium",
+    "symbol": "ARX",
+    "decimals": 9,
+    "logoURI": "https://s2.coinmarketcap.com/static/img/coins/64x64/39970.png"
   }
 ]


### PR DESCRIPTION
## Summary
Add 2 tokens to the default list.

| Symbol | Chain | Address | Decimals |
|--------|-------|---------|----------|
| RE | Ethereum | `0x526526528F35AC738177003b8773B402B8Df8143` | 18 |
| ARX | Solana | `ARXwZkNAtzPfdcoqQiduJn8EPv9fKiDfGn2KyggyDrFs` | 9 |

## Verification
- [x] EIP-55 checksums verified
- [x] No duplicate entries
- [x] `yarn test` passes

## Linear tickets
- [CONS-2338](https://linear.app/uniswap/issue/CONS-2338/default-token-list-addition-re)
- [CONS-2337](https://linear.app/uniswap/issue/CONS-2337/default-token-list-addition-arcium)

🤖 Generated with [Claude Code](https://claude.com/claude-code)