### PR TITLE
add: JITOSOL (2026-06-15)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uniswap/default-token-list",
-  "version": "22.1.0",
+  "version": "22.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@uniswap/default-token-list",
-      "version": "22.1.0",
+      "version": "22.2.0",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "@ethersproject/address": "^5.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/default-token-list",
-  "version": "22.1.0",
+  "version": "22.2.0",
   "description": "The Uniswap default token list",
   "main": "build/uniswap-default.tokenlist.json",
   "scripts": {

--- a/src/tokens/base.json
+++ b/src/tokens/base.json
@@ -683,5 +683,13 @@
     "name": "o1.exchange",
     "symbol": "O",
     "decimals": 18
+  },
+  {
+    "chainId": 8453,
+    "address": "0x97bE14Dd8f994A5364573BC035D85309E7CB34de",
+    "name": "Jito Staked SOL",
+    "symbol": "JITOSOL",
+    "decimals": 9,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/28046/large/JitoSOL_Token_Logo_Green.png?1779807693"
   }
 ]


### PR DESCRIPTION
## Summary
Add 1 token to the default list.

| Symbol | Chain | Address | Decimals |
|--------|-------|---------|----------|
| JITOSOL | Base | `0x97bE14Dd8f994A5364573BC035D85309E7CB34de` | 9 |

## Verification
- [x] EIP-55 checksums verified
- [x] No duplicate entries
- [x] `yarn test` passes

## Linear tickets
- [CONS-2385](https://linear.app/uniswap/issue/CONS-2385/default-token-list-addition-jito-staked-sol)