### PR TITLE
add: GEOD, YOM (2026-06-18)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uniswap/default-token-list",
-  "version": "22.2.0",
+  "version": "22.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@uniswap/default-token-list",
-      "version": "22.2.0",
+      "version": "22.3.0",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "@ethersproject/address": "^5.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/default-token-list",
-  "version": "22.2.0",
+  "version": "22.3.0",
   "description": "The Uniswap default token list",
   "main": "build/uniswap-default.tokenlist.json",
   "scripts": {

--- a/src/tokens/avalanche.json
+++ b/src/tokens/avalanche.json
@@ -94,5 +94,13 @@
     "symbol": "AUSD",
     "decimals": 6,
     "logoURI": "https://coin-images.coingecko.com/coins/images/39284/large/AUSD_1024px.png?1764684132"
+  },
+  {
+    "chainId": 43114,
+    "address": "0xb6314518b61b4864162c7aE7fdc36261e0A14C4b",
+    "name": "YOM",
+    "symbol": "YOM",
+    "decimals": 18,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/102172602/large/YOM_TOKEN_LOGO_200x200.png?1774193038"
   }
 ]

--- a/src/tokens/solana.json
+++ b/src/tokens/solana.json
@@ -1446,5 +1446,13 @@
     "symbol": "ARX",
     "decimals": 9,
     "logoURI": "https://s2.coinmarketcap.com/static/img/coins/64x64/39970.png"
+  },
+  {
+    "chainId": 501000101,
+    "address": "7JA5eZdCzztSfQbJvS8aVVxMFfd81Rs9VvwnocV1mKHu",
+    "name": "GEODNET",
+    "symbol": "GEOD",
+    "decimals": 9,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/31608/large/Circular_White.png?1696530424"
   }
 ]


### PR DESCRIPTION
## Summary
Add 2 tokens to the default list. These come from two Linear tickets whose automated run ([#27784987382](https://github.com/Uniswap/default-token-list/actions/runs/27784987382)) timed out (30m execution limit) before completing; re-running them manually here.

| Symbol | Chain | Address | Decimals |
|--------|-------|---------|----------|
| GEOD | Solana | `7JA5eZdCzztSfQbJvS8aVVxMFfd81Rs9VvwnocV1mKHu` | 9 |
| YOM | Avalanche | `0xb6314518b61b4864162c7aE7fdc36261e0A14C4b` | 18 |

## Verification
- [x] EIP-55 checksum verified (YOM); GEOD is a valid base58 Solana address
- [x] No duplicate entries
- [x] `yarn test` passes (6 passing)

## Linear tickets
- [CONS-2407](https://linear.app/uniswap/issue/CONS-2407/default-token-list-addition-geodnet) — GEODNET (GEOD)
- [CONS-2409](https://linear.app/uniswap/issue/CONS-2409/default-token-list-addition-yom) — YOM