### PR TITLE
add: CAP, GROVE, NES (2026-07-02)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uniswap/default-token-list",
-  "version": "22.3.0",
+  "version": "22.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@uniswap/default-token-list",
-      "version": "22.3.0",
+      "version": "22.4.0",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "@ethersproject/address": "^5.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/default-token-list",
-  "version": "22.3.0",
+  "version": "22.4.0",
   "description": "The Uniswap default token list",
   "main": "build/uniswap-default.tokenlist.json",
   "scripts": {

--- a/src/tokens/bnb.json
+++ b/src/tokens/bnb.json
@@ -118,5 +118,13 @@
     "symbol": "AUSD",
     "decimals": 6,
     "logoURI": "https://coin-images.coingecko.com/coins/images/39284/large/AUSD_1024px.png?1764684132"
+  },
+  {
+    "chainId": 56,
+    "address": "0x3131f6B80C26936aB03F7d9D29Eb4Ddf36AC3FB5",
+    "name": "Nesa",
+    "symbol": "NES",
+    "decimals": 18,
+    "logoURI": "https://s2.coinmarketcap.com/static/img/coins/64x64/30140.png"
   }
 ]

--- a/src/tokens/bnb.json
+++ b/src/tokens/bnb.json
@@ -125,6 +125,6 @@
     "name": "Nesa",
     "symbol": "NES",
     "decimals": 18,
-    "logoURI": "https://s2.coinmarketcap.com/static/img/coins/64x64/30140.png"
+    "logoURI": "https://s2.coinmarketcap.com/static/img/coins/128x128/30140.png"
   }
 ]

--- a/src/tokens/mainnet.json
+++ b/src/tokens/mainnet.json
@@ -3230,5 +3230,28 @@
     "symbol": "RE",
     "decimals": 18,
     "logoURI": "https://assets.coingecko.com/coins/images/102173708/standard/RE-Token.png?1781031591"
+  },
+  {
+    "chainId": 1,
+    "address": "0x99991c6AAbba5a096f24f250b73580F5179b9999",
+    "name": "Cap",
+    "symbol": "CAP",
+    "decimals": 18,
+    "logoURI": "https://s2.coinmarketcap.com/static/img/coins/64x64/40531.png"
+  },
+  {
+    "chainId": 1,
+    "address": "0xB30FE1Cf884B48a22a50D22a9282004F2c5E9406",
+    "name": "Grove",
+    "symbol": "GROVE",
+    "decimals": 18
+  },
+  {
+    "chainId": 1,
+    "address": "0x230f1E241C621d5af670Dad83ebCdd18971E2995",
+    "name": "Nesa",
+    "symbol": "NES",
+    "decimals": 18,
+    "logoURI": "https://s2.coinmarketcap.com/static/img/coins/64x64/30140.png"
   }
 ]

--- a/src/tokens/mainnet.json
+++ b/src/tokens/mainnet.json
@@ -3150,7 +3150,7 @@
     "name": "Wrapped Ronin",
     "symbol": "WRON",
     "decimals": 18,
-    "logoURI": "https://s2.coinmarketcap.com/static/img/coins/64x64/27983.png"
+    "logoURI": "https://s2.coinmarketcap.com/static/img/coins/128x128/27983.png"
   },
   {
     "chainId": 1,
@@ -3237,7 +3237,7 @@
     "name": "Cap",
     "symbol": "CAP",
     "decimals": 18,
-    "logoURI": "https://s2.coinmarketcap.com/static/img/coins/64x64/40531.png"
+    "logoURI": "https://s2.coinmarketcap.com/static/img/coins/128x128/40531.png"
   },
   {
     "chainId": 1,
@@ -3252,6 +3252,6 @@
     "name": "Nesa",
     "symbol": "NES",
     "decimals": 18,
-    "logoURI": "https://s2.coinmarketcap.com/static/img/coins/64x64/30140.png"
+    "logoURI": "https://s2.coinmarketcap.com/static/img/coins/128x128/30140.png"
   }
 ]


### PR DESCRIPTION
## Summary
Add 3 tokens (4 entries across 2 chains) to the default list. Consolidated from multiple open requests into a single PR.

| Symbol | Chain | Address | Decimals |
|--------|-------|---------|----------|
| CAP | Ethereum | `0x99991c6AAbba5a096f24f250b73580F5179b9999` | 18 |
| GROVE | Ethereum | `0xB30FE1Cf884B48a22a50D22a9282004F2c5E9406` | 18 |
| NES | Ethereum | `0x230f1E241C621d5af670Dad83ebCdd18971E2995` | 18 |
| NES | BNB Chain | `0x3131f6B80C26936aB03F7d9D29Eb4Ddf36AC3FB5` | 18 |

Note: GROVE is added without a `logoURI` — the Linear ticket listed the image as "Unknown at this time".

## Verification
- [x] EIP-55 checksums verified
- [x] No duplicate entries
- [x] `yarn test` passes

## Linear tickets
- [CONS-2463](https://linear.app/uniswap/issue/CONS-2463/default-token-list-addition-cap)
- [CONS-2506](https://linear.app/uniswap/issue/CONS-2506/default-token-list-addition-grove)
- [CONS-2507](https://linear.app/uniswap/issue/CONS-2507/default-token-list-addition-nesa)