### PR TITLE
add: Bankcoin kStable family (38 tokens on Base + 38 on Arbitrum)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/default-token-list",
-  "version": "22.4.0",
+  "version": "22.5.0",
   "description": "The Uniswap default token list",
   "main": "build/uniswap-default.tokenlist.json",
   "scripts": {

--- a/src/tokens/arbitrum.json
+++ b/src/tokens/arbitrum.json
@@ -118,5 +118,309 @@
     "symbol": "AUSD",
     "decimals": 6,
     "logoURI": "https://coin-images.coingecko.com/coins/images/39284/large/AUSD_1024px.png?1764684132"
+  },
+  {
+    "chainId": 42161,
+    "address": "0x0A97E78Dc2169661aD7709d1a6b97ECb60B0c5C1",
+    "name": "Bankcoin UAE Dirham",
+    "symbol": "kAED",
+    "decimals": 6,
+    "logoURI": "https://assets.bankcoin.capital/icons/kstables/kAED.png"
+  },
+  {
+    "chainId": 42161,
+    "address": "0x2c4Fc907c6b6326B078cC4a4FBA5410884207261",
+    "name": "Bankcoin Argentine Peso",
+    "symbol": "kARS",
+    "decimals": 6,
+    "logoURI": "https://assets.bankcoin.capital/icons/kstables/kARS.png"
+  },
+  {
+    "chainId": 42161,
+    "address": "0x713E7aF0c03a6C75267E3C52c8a8bFE496C80daC",
+    "name": "Bankcoin Australian Dollar",
+    "symbol": "kAUD",
+    "decimals": 6,
+    "logoURI": "https://assets.bankcoin.capital/icons/kstables/kAUD.png"
+  },
+  {
+    "chainId": 42161,
+    "address": "0x30186D1d9a15accB7cE0913d30c00dFf8B265E05",
+    "name": "Bankcoin Bangladeshi Taka",
+    "symbol": "kBDT",
+    "decimals": 6,
+    "logoURI": "https://assets.bankcoin.capital/icons/kstables/kBDT.png"
+  },
+  {
+    "chainId": 42161,
+    "address": "0xbbb3099fa4a9870232f2106cd27041178780051D",
+    "name": "Bankcoin Brazilian Real",
+    "symbol": "kBRL",
+    "decimals": 6,
+    "logoURI": "https://assets.bankcoin.capital/icons/kstables/kBRL.png"
+  },
+  {
+    "chainId": 42161,
+    "address": "0x5f7cDa7328E114690a1836Cc39B659604C955D0d",
+    "name": "Bankcoin Canadian Dollar",
+    "symbol": "kCAD",
+    "decimals": 6,
+    "logoURI": "https://assets.bankcoin.capital/icons/kstables/kCAD.png"
+  },
+  {
+    "chainId": 42161,
+    "address": "0x8E25F1EF537AEF95745468F9174587B764452e9C",
+    "name": "Bankcoin Swiss Franc",
+    "symbol": "kCHF",
+    "decimals": 6,
+    "logoURI": "https://assets.bankcoin.capital/icons/kstables/kCHF.png"
+  },
+  {
+    "chainId": 42161,
+    "address": "0x560cf127Fe663442fD327cC37C8005bC48a057f3",
+    "name": "Bankcoin Offshore Yuan",
+    "symbol": "kCNH",
+    "decimals": 6,
+    "logoURI": "https://assets.bankcoin.capital/icons/kstables/kCNH.png"
+  },
+  {
+    "chainId": 42161,
+    "address": "0x5fcFe0A8FC01526175e1e2047750F64cEbe36E7a",
+    "name": "Bankcoin Egyptian Pound",
+    "symbol": "kEGP",
+    "decimals": 6,
+    "logoURI": "https://assets.bankcoin.capital/icons/kstables/kEGP.png"
+  },
+  {
+    "chainId": 42161,
+    "address": "0x4f2039Ae7973c5e5236DB3E0A1E892288894c998",
+    "name": "Bankcoin Euro",
+    "symbol": "kEUR",
+    "decimals": 6,
+    "logoURI": "https://assets.bankcoin.capital/icons/kstables/kEUR.png"
+  },
+  {
+    "chainId": 42161,
+    "address": "0xca4FEB7B88C6A9f3bF10fF0176B05178FCa58E61",
+    "name": "Bankcoin British Pound",
+    "symbol": "kGBP",
+    "decimals": 6,
+    "logoURI": "https://assets.bankcoin.capital/icons/kstables/kGBP.png"
+  },
+  {
+    "chainId": 42161,
+    "address": "0xb915A2bd6C165BbcbFCC0b5e75bb5065BACA8aCC",
+    "name": "Bankcoin Ghanaian Cedi",
+    "symbol": "kGHS",
+    "decimals": 6,
+    "logoURI": "https://assets.bankcoin.capital/icons/kstables/kGHS.png"
+  },
+  {
+    "chainId": 42161,
+    "address": "0x95Ba1C0D50598052ef1eE55749B7547280afa762",
+    "name": "Bankcoin Hong Kong Dollar",
+    "symbol": "kHKD",
+    "decimals": 6,
+    "logoURI": "https://assets.bankcoin.capital/icons/kstables/kHKD.png"
+  },
+  {
+    "chainId": 42161,
+    "address": "0x579c49E9e87fd6A8483314D9A031A24417D2F585",
+    "name": "Bankcoin Indonesian Rupiah",
+    "symbol": "kIDR",
+    "decimals": 6,
+    "logoURI": "https://assets.bankcoin.capital/icons/kstables/kIDR.png"
+  },
+  {
+    "chainId": 42161,
+    "address": "0x2F0923ACbCF115Ced314DD1b3091845F032BF371",
+    "name": "Bankcoin Israeli Shekel",
+    "symbol": "kILS",
+    "decimals": 6,
+    "logoURI": "https://assets.bankcoin.capital/icons/kstables/kILS.png"
+  },
+  {
+    "chainId": 42161,
+    "address": "0x436Cca680EFC191E2cb524743B2258b935A326f8",
+    "name": "Bankcoin Indian Rupee",
+    "symbol": "kINR",
+    "decimals": 6,
+    "logoURI": "https://assets.bankcoin.capital/icons/kstables/kINR.png"
+  },
+  {
+    "chainId": 42161,
+    "address": "0x0E8cC7bb79518D355264688D8Cce2895127BeB06",
+    "name": "Bankcoin Japanese Yen",
+    "symbol": "kJPY",
+    "decimals": 6,
+    "logoURI": "https://assets.bankcoin.capital/icons/kstables/kJPY.png"
+  },
+  {
+    "chainId": 42161,
+    "address": "0x7eE4FB9B8F866150C550516991b6C33DacD518a9",
+    "name": "Bankcoin Kenyan Shilling",
+    "symbol": "kKES",
+    "decimals": 6,
+    "logoURI": "https://assets.bankcoin.capital/icons/kstables/kKES.png"
+  },
+  {
+    "chainId": 42161,
+    "address": "0x17067A34972699C38cef0ab6Fad6a40299A01FB5",
+    "name": "Bankcoin Korean Won",
+    "symbol": "kKRW",
+    "decimals": 6,
+    "logoURI": "https://assets.bankcoin.capital/icons/kstables/kKRW.png"
+  },
+  {
+    "chainId": 42161,
+    "address": "0x94428676620c4444947b4f3E6A4E0D475396F75B",
+    "name": "Bankcoin Mexican Peso",
+    "symbol": "kMXN",
+    "decimals": 6,
+    "logoURI": "https://assets.bankcoin.capital/icons/kstables/kMXN.png"
+  },
+  {
+    "chainId": 42161,
+    "address": "0x1fcde2803fc75824E6283EC643078D9495A232Ef",
+    "name": "Bankcoin Malaysian Ringgit",
+    "symbol": "kMYR",
+    "decimals": 6,
+    "logoURI": "https://assets.bankcoin.capital/icons/kstables/kMYR.png"
+  },
+  {
+    "chainId": 42161,
+    "address": "0x2d631C5D159d1453eF219B2746B89B52FaCA2865",
+    "name": "Bankcoin Nigerian Naira",
+    "symbol": "kNGN",
+    "decimals": 6,
+    "logoURI": "https://assets.bankcoin.capital/icons/kstables/kNGN.png"
+  },
+  {
+    "chainId": 42161,
+    "address": "0xC0522C96b469F85a743fD9fafb97F0e6993CB6f4",
+    "name": "Bankcoin Norwegian Krone",
+    "symbol": "kNOK",
+    "decimals": 6,
+    "logoURI": "https://assets.bankcoin.capital/icons/kstables/kNOK.png"
+  },
+  {
+    "chainId": 42161,
+    "address": "0x4D6dbEA3Fb4eC468e52812F7992b39d8d6Cb4415",
+    "name": "Bankcoin New Zealand Dollar",
+    "symbol": "kNZD",
+    "decimals": 6,
+    "logoURI": "https://assets.bankcoin.capital/icons/kstables/kNZD.png"
+  },
+  {
+    "chainId": 42161,
+    "address": "0xfd2d57f1b72eD0E11fA63358Ccc001615A6BF210",
+    "name": "Bankcoin Philippine Peso",
+    "symbol": "kPHP",
+    "decimals": 6,
+    "logoURI": "https://assets.bankcoin.capital/icons/kstables/kPHP.png"
+  },
+  {
+    "chainId": 42161,
+    "address": "0x9CC6Eaad305f897997f095d346388B9ca1AA8143",
+    "name": "Bankcoin Pakistani Rupee",
+    "symbol": "kPKR",
+    "decimals": 6,
+    "logoURI": "https://assets.bankcoin.capital/icons/kstables/kPKR.png"
+  },
+  {
+    "chainId": 42161,
+    "address": "0xEB74732B4333963fEED124785B462Ad4BECb843e",
+    "name": "Bankcoin Polish Zloty",
+    "symbol": "kPLN",
+    "decimals": 6,
+    "logoURI": "https://assets.bankcoin.capital/icons/kstables/kPLN.png"
+  },
+  {
+    "chainId": 42161,
+    "address": "0xf9225263624104F8f0C12c88901c6330a5b2ca44",
+    "name": "Bankcoin Saudi Riyal",
+    "symbol": "kSAR",
+    "decimals": 6,
+    "logoURI": "https://assets.bankcoin.capital/icons/kstables/kSAR.png"
+  },
+  {
+    "chainId": 42161,
+    "address": "0x570cdF023703aBdb0e0a96b07F997dfBcBc3F002",
+    "name": "Bankcoin Swedish Krona",
+    "symbol": "kSEK",
+    "decimals": 6,
+    "logoURI": "https://assets.bankcoin.capital/icons/kstables/kSEK.png"
+  },
+  {
+    "chainId": 42161,
+    "address": "0xA96FC8E4D68F5Da6bC4C07e34E3f7377C843bCb7",
+    "name": "Bankcoin Singapore Dollar",
+    "symbol": "kSGD",
+    "decimals": 6,
+    "logoURI": "https://assets.bankcoin.capital/icons/kstables/kSGD.png"
+  },
+  {
+    "chainId": 42161,
+    "address": "0xb274bEce9BEb46DfdDddC4460DF881b3cEAd46f3",
+    "name": "Bankcoin Thai Baht",
+    "symbol": "kTHB",
+    "decimals": 6,
+    "logoURI": "https://assets.bankcoin.capital/icons/kstables/kTHB.png"
+  },
+  {
+    "chainId": 42161,
+    "address": "0xB45a3767D94f580259A2495A280dA2d3dF6922A3",
+    "name": "Bankcoin Turkish Lira",
+    "symbol": "kTRY",
+    "decimals": 6,
+    "logoURI": "https://assets.bankcoin.capital/icons/kstables/kTRY.png"
+  },
+  {
+    "chainId": 42161,
+    "address": "0xcf4Bf48E3142376552114e456412672A190FAb91",
+    "name": "Bankcoin Taiwan Dollar",
+    "symbol": "kTWD",
+    "decimals": 6,
+    "logoURI": "https://assets.bankcoin.capital/icons/kstables/kTWD.png"
+  },
+  {
+    "chainId": 42161,
+    "address": "0x4653092872bE819CdFf244db8a474BBaeAA2B024",
+    "name": "Bankcoin US Dollar",
+    "symbol": "kUSD",
+    "decimals": 6,
+    "logoURI": "https://assets.bankcoin.capital/icons/kstables/kUSD.png"
+  },
+  {
+    "chainId": 42161,
+    "address": "0x66E6C24944a4f65B5E4ffe82Ad36215DeECa03eE",
+    "name": "Bankcoin Vietnamese Dong",
+    "symbol": "kVND",
+    "decimals": 6,
+    "logoURI": "https://assets.bankcoin.capital/icons/kstables/kVND.png"
+  },
+  {
+    "chainId": 42161,
+    "address": "0x4FDed706cF589039a31997e9F43a8E87A3c38Bdf",
+    "name": "Bankcoin Central African CFA Franc",
+    "symbol": "kXAF",
+    "decimals": 6,
+    "logoURI": "https://assets.bankcoin.capital/icons/kstables/kXAF.png"
+  },
+  {
+    "chainId": 42161,
+    "address": "0xeC337A0BedD24B5616F284b80cCA85648335bCae",
+    "name": "Bankcoin West African CFA Franc",
+    "symbol": "kXOF",
+    "decimals": 6,
+    "logoURI": "https://assets.bankcoin.capital/icons/kstables/kXOF.png"
+  },
+  {
+    "chainId": 42161,
+    "address": "0x3a4bBBA012A016Ee461BA62E9561c3248211422F",
+    "name": "Bankcoin South African Rand",
+    "symbol": "kZAR",
+    "decimals": 6,
+    "logoURI": "https://assets.bankcoin.capital/icons/kstables/kZAR.png"
   }
 ]

--- a/src/tokens/base.json
+++ b/src/tokens/base.json
@@ -691,5 +691,309 @@
     "symbol": "JITOSOL",
     "decimals": 9,
     "logoURI": "https://coin-images.coingecko.com/coins/images/28046/large/JitoSOL_Token_Logo_Green.png?1779807693"
+  },
+  {
+    "chainId": 8453,
+    "address": "0xca4FEB7B88C6A9f3bF10fF0176B05178FCa58E61",
+    "name": "Bankcoin UAE Dirham",
+    "symbol": "kAED",
+    "decimals": 6,
+    "logoURI": "https://assets.bankcoin.capital/icons/kstables/kAED.png"
+  },
+  {
+    "chainId": 8453,
+    "address": "0x4f2039Ae7973c5e5236DB3E0A1E892288894c998",
+    "name": "Bankcoin Argentine Peso",
+    "symbol": "kARS",
+    "decimals": 6,
+    "logoURI": "https://assets.bankcoin.capital/icons/kstables/kARS.png"
+  },
+  {
+    "chainId": 8453,
+    "address": "0xeaF04dF1b08A6a72369553f886f2CcfA0205eF4B",
+    "name": "Bankcoin Australian Dollar",
+    "symbol": "kAUD",
+    "decimals": 6,
+    "logoURI": "https://assets.bankcoin.capital/icons/kstables/kAUD.png"
+  },
+  {
+    "chainId": 8453,
+    "address": "0x18B258185Fed7571732bF31AE0FD887820969D2e",
+    "name": "Bankcoin Bangladeshi Taka",
+    "symbol": "kBDT",
+    "decimals": 6,
+    "logoURI": "https://assets.bankcoin.capital/icons/kstables/kBDT.png"
+  },
+  {
+    "chainId": 8453,
+    "address": "0xD3F212dbca70cD493F1D3A20407aABAe34bE3117",
+    "name": "Bankcoin Brazilian Real",
+    "symbol": "kBRL",
+    "decimals": 6,
+    "logoURI": "https://assets.bankcoin.capital/icons/kstables/kBRL.png"
+  },
+  {
+    "chainId": 8453,
+    "address": "0xB54B1edc7622f6f7E2a3549E019eCdf5B1941DB4",
+    "name": "Bankcoin Canadian Dollar",
+    "symbol": "kCAD",
+    "decimals": 6,
+    "logoURI": "https://assets.bankcoin.capital/icons/kstables/kCAD.png"
+  },
+  {
+    "chainId": 8453,
+    "address": "0xB64249DA945C3e81f0708069c31B0C0F36D4D806",
+    "name": "Bankcoin Swiss Franc",
+    "symbol": "kCHF",
+    "decimals": 6,
+    "logoURI": "https://assets.bankcoin.capital/icons/kstables/kCHF.png"
+  },
+  {
+    "chainId": 8453,
+    "address": "0x68A40D02d1c7F477d1c3D4E60C6A35a737775c0A",
+    "name": "Bankcoin Offshore Yuan",
+    "symbol": "kCNH",
+    "decimals": 6,
+    "logoURI": "https://assets.bankcoin.capital/icons/kstables/kCNH.png"
+  },
+  {
+    "chainId": 8453,
+    "address": "0x5f7cDa7328E114690a1836Cc39B659604C955D0d",
+    "name": "Bankcoin Egyptian Pound",
+    "symbol": "kEGP",
+    "decimals": 6,
+    "logoURI": "https://assets.bankcoin.capital/icons/kstables/kEGP.png"
+  },
+  {
+    "chainId": 8453,
+    "address": "0xf9dC39A53F58c6F3e2bcfD44eBbb1585Ced0175e",
+    "name": "Bankcoin Euro",
+    "symbol": "kEUR",
+    "decimals": 6,
+    "logoURI": "https://assets.bankcoin.capital/icons/kstables/kEUR.png"
+  },
+  {
+    "chainId": 8453,
+    "address": "0x372117419A8c0F59A79d7fFd8F4A5C6a2b347EDa",
+    "name": "Bankcoin British Pound",
+    "symbol": "kGBP",
+    "decimals": 6,
+    "logoURI": "https://assets.bankcoin.capital/icons/kstables/kGBP.png"
+  },
+  {
+    "chainId": 8453,
+    "address": "0x81E7847566E9EfB7e557a4f672B75b1789007b5b",
+    "name": "Bankcoin Ghanaian Cedi",
+    "symbol": "kGHS",
+    "decimals": 6,
+    "logoURI": "https://assets.bankcoin.capital/icons/kstables/kGHS.png"
+  },
+  {
+    "chainId": 8453,
+    "address": "0x0E8cC7bb79518D355264688D8Cce2895127BeB06",
+    "name": "Bankcoin Hong Kong Dollar",
+    "symbol": "kHKD",
+    "decimals": 6,
+    "logoURI": "https://assets.bankcoin.capital/icons/kstables/kHKD.png"
+  },
+  {
+    "chainId": 8453,
+    "address": "0x3A61A43c0ef285d05396c91c4BeAc26F960d2f9E",
+    "name": "Bankcoin Indonesian Rupiah",
+    "symbol": "kIDR",
+    "decimals": 6,
+    "logoURI": "https://assets.bankcoin.capital/icons/kstables/kIDR.png"
+  },
+  {
+    "chainId": 8453,
+    "address": "0xD297e86f33fc01620d07e27BA5B7006e649cb649",
+    "name": "Bankcoin Israeli Shekel",
+    "symbol": "kILS",
+    "decimals": 6,
+    "logoURI": "https://assets.bankcoin.capital/icons/kstables/kILS.png"
+  },
+  {
+    "chainId": 8453,
+    "address": "0xac99f373934E44a027b54c1D75222fdc5075448d",
+    "name": "Bankcoin Indian Rupee",
+    "symbol": "kINR",
+    "decimals": 6,
+    "logoURI": "https://assets.bankcoin.capital/icons/kstables/kINR.png"
+  },
+  {
+    "chainId": 8453,
+    "address": "0xA65CC044383BE92522C9Ce0287838ADd3c999cDb",
+    "name": "Bankcoin Japanese Yen",
+    "symbol": "kJPY",
+    "decimals": 6,
+    "logoURI": "https://assets.bankcoin.capital/icons/kstables/kJPY.png"
+  },
+  {
+    "chainId": 8453,
+    "address": "0xee2aA52C8485564CFcdba83CA0EaA9757021d781",
+    "name": "Bankcoin Kenyan Shilling",
+    "symbol": "kKES",
+    "decimals": 6,
+    "logoURI": "https://assets.bankcoin.capital/icons/kstables/kKES.png"
+  },
+  {
+    "chainId": 8453,
+    "address": "0x0D8afa452EEA89d944D7cf39F111207A02ABb2Aa",
+    "name": "Bankcoin Korean Won",
+    "symbol": "kKRW",
+    "decimals": 6,
+    "logoURI": "https://assets.bankcoin.capital/icons/kstables/kKRW.png"
+  },
+  {
+    "chainId": 8453,
+    "address": "0x0102D2c860aBdC8e2D1DF04CdC42b593D5a198e3",
+    "name": "Bankcoin Mexican Peso",
+    "symbol": "kMXN",
+    "decimals": 6,
+    "logoURI": "https://assets.bankcoin.capital/icons/kstables/kMXN.png"
+  },
+  {
+    "chainId": 8453,
+    "address": "0x5ff3473989Dfc004AF09d96f2F473769d60d170a",
+    "name": "Bankcoin Malaysian Ringgit",
+    "symbol": "kMYR",
+    "decimals": 6,
+    "logoURI": "https://assets.bankcoin.capital/icons/kstables/kMYR.png"
+  },
+  {
+    "chainId": 8453,
+    "address": "0xd0a0042139d1Febe85b2FfC4f7049E059a6d949F",
+    "name": "Bankcoin Nigerian Naira",
+    "symbol": "kNGN",
+    "decimals": 6,
+    "logoURI": "https://assets.bankcoin.capital/icons/kstables/kNGN.png"
+  },
+  {
+    "chainId": 8453,
+    "address": "0x17067A34972699C38cef0ab6Fad6a40299A01FB5",
+    "name": "Bankcoin Norwegian Krone",
+    "symbol": "kNOK",
+    "decimals": 6,
+    "logoURI": "https://assets.bankcoin.capital/icons/kstables/kNOK.png"
+  },
+  {
+    "chainId": 8453,
+    "address": "0x8E25F1EF537AEF95745468F9174587B764452e9C",
+    "name": "Bankcoin New Zealand Dollar",
+    "symbol": "kNZD",
+    "decimals": 6,
+    "logoURI": "https://assets.bankcoin.capital/icons/kstables/kNZD.png"
+  },
+  {
+    "chainId": 8453,
+    "address": "0x94428676620c4444947b4f3E6A4E0D475396F75B",
+    "name": "Bankcoin Philippine Peso",
+    "symbol": "kPHP",
+    "decimals": 6,
+    "logoURI": "https://assets.bankcoin.capital/icons/kstables/kPHP.png"
+  },
+  {
+    "chainId": 8453,
+    "address": "0x7B8d769C00331a899802B3fa416f8c8F29f2F04F",
+    "name": "Bankcoin Pakistani Rupee",
+    "symbol": "kPKR",
+    "decimals": 6,
+    "logoURI": "https://assets.bankcoin.capital/icons/kstables/kPKR.png"
+  },
+  {
+    "chainId": 8453,
+    "address": "0x7acA07601659d85bA9f712779A2e82B8708B1Fc5",
+    "name": "Bankcoin Polish Zloty",
+    "symbol": "kPLN",
+    "decimals": 6,
+    "logoURI": "https://assets.bankcoin.capital/icons/kstables/kPLN.png"
+  },
+  {
+    "chainId": 8453,
+    "address": "0x4653092872bE819CdFf244db8a474BBaeAA2B024",
+    "name": "Bankcoin Saudi Riyal",
+    "symbol": "kSAR",
+    "decimals": 6,
+    "logoURI": "https://assets.bankcoin.capital/icons/kstables/kSAR.png"
+  },
+  {
+    "chainId": 8453,
+    "address": "0x436Cca680EFC191E2cb524743B2258b935A326f8",
+    "name": "Bankcoin Swedish Krona",
+    "symbol": "kSEK",
+    "decimals": 6,
+    "logoURI": "https://assets.bankcoin.capital/icons/kstables/kSEK.png"
+  },
+  {
+    "chainId": 8453,
+    "address": "0x713E7aF0c03a6C75267E3C52c8a8bFE496C80daC",
+    "name": "Bankcoin Singapore Dollar",
+    "symbol": "kSGD",
+    "decimals": 6,
+    "logoURI": "https://assets.bankcoin.capital/icons/kstables/kSGD.png"
+  },
+  {
+    "chainId": 8453,
+    "address": "0x560cf127Fe663442fD327cC37C8005bC48a057f3",
+    "name": "Bankcoin Thai Baht",
+    "symbol": "kTHB",
+    "decimals": 6,
+    "logoURI": "https://assets.bankcoin.capital/icons/kstables/kTHB.png"
+  },
+  {
+    "chainId": 8453,
+    "address": "0x31F4e0F58435A7e713886264b0030B5d0fD79cEb",
+    "name": "Bankcoin Turkish Lira",
+    "symbol": "kTRY",
+    "decimals": 6,
+    "logoURI": "https://assets.bankcoin.capital/icons/kstables/kTRY.png"
+  },
+  {
+    "chainId": 8453,
+    "address": "0x7F423E8c9a3e4F2F82e6461BC9f6c3fae9C8f2eA",
+    "name": "Bankcoin Taiwan Dollar",
+    "symbol": "kTWD",
+    "decimals": 6,
+    "logoURI": "https://assets.bankcoin.capital/icons/kstables/kTWD.png"
+  },
+  {
+    "chainId": 8453,
+    "address": "0x6FB09847417e33A1CE75d3B324015D4C0AeF4D61",
+    "name": "Bankcoin US Dollar",
+    "symbol": "kUSD",
+    "decimals": 6,
+    "logoURI": "https://assets.bankcoin.capital/icons/kstables/kUSD.png"
+  },
+  {
+    "chainId": 8453,
+    "address": "0x451f8C9FD15e2f81CC0e514cC6a5724Dd3537dAc",
+    "name": "Bankcoin Vietnamese Dong",
+    "symbol": "kVND",
+    "decimals": 6,
+    "logoURI": "https://assets.bankcoin.capital/icons/kstables/kVND.png"
+  },
+  {
+    "chainId": 8453,
+    "address": "0x02500b0c823C5f66A3A26005E04808f46e0eefdb",
+    "name": "Bankcoin Central African CFA Franc",
+    "symbol": "kXAF",
+    "decimals": 6,
+    "logoURI": "https://assets.bankcoin.capital/icons/kstables/kXAF.png"
+  },
+  {
+    "chainId": 8453,
+    "address": "0x5916742182196dD698cC3678b723eFf46a81dFFd",
+    "name": "Bankcoin West African CFA Franc",
+    "symbol": "kXOF",
+    "decimals": 6,
+    "logoURI": "https://assets.bankcoin.capital/icons/kstables/kXOF.png"
+  },
+  {
+    "chainId": 8453,
+    "address": "0x88c94e53B8b2CeCEA508892b2df24060ed08F0db",
+    "name": "Bankcoin South African Rand",
+    "symbol": "kZAR",
+    "decimals": 6,
+    "logoURI": "https://assets.bankcoin.capital/icons/kstables/kZAR.png"
   }
 ]


### PR DESCRIPTION
## Summary
Add the full Bankcoin Capital kStable family — **76 entries** (38 FX-referenced stablecoins × Base `8453` + Arbitrum One `42161`) to the default list. One kStable per major and emerging-market currency, all 6-decimal, all with live supply and Uniswap v3 liquidity.

Source of truth: https://assets.bankcoin.capital/tokenlist.json (conforms to the Uniswap token-lists schema). Circulating supply is reproducible from public RPC reads: https://assets.bankcoin.capital/supply/circulating

Symbols (both chains): kAED, kARS, kAUD, kBDT, kBRL, kCAD, kCHF, kCNH, kEGP, kEUR, kGBP, kGHS, kHKD, kIDR, kILS, kINR, kJPY, kKES, kKRW, kMXN, kMYR, kNGN, kNOK, kNZD, kPHP, kPKR, kPLN, kSAR, kSEK, kSGD, kTHB, kTRY, kTWD, kUSD, kVND, kXAF, kXOF, kZAR.

Flagships:
| Symbol | Chain | Address | Decimals |
|--------|-------|---------|----------|
| kUSD | Base (8453) | `0x6FB09847417e33A1CE75d3B324015D4C0AeF4D61` | 6 |
| kEUR | Base (8453) | `0xf9dC39A53F58c6F3e2bcfD44eBbb1585Ced0175e` | 6 |
| kUSD | Arbitrum One (42161) | `0x4653092872bE819CdFf244db8a474BBaeAA2B024` | 6 |
| kEUR | Arbitrum One (42161) | `0x4f2039Ae7973c5e5236DB3E0A1E892288894c998` | 6 |

## Verification
- [x] Every address EIP-55 checksummed (`cast to-check-sum-address` on all 76)
- [x] `symbol` / `decimals` sourced from the on-chain-validated token list; decimals = 6 for all
- [x] No duplicate `chainId`+address, symbol, or name introduced by these entries
- [x] Logos are 256x256 PNG at `https://assets.bankcoin.capital/icons/kstables/<SYMBOL>.png`, served with CORS `*`
- [x] Minor version bump (22.4.0 → 22.5.0) per the additions rule
- [x] All 76 entries pass the list assertions (checksum / no-duplicate / decimals 0–18) when validated in isolation with the repo's own `@ethersproject/address`

## Note
`yarn test` currently fails on `main` before reaching schema checks due to a **pre-existing** duplicate on Base unrelated to this PR — token `B3` at `0xB3B32F9f8827D4634fE7d973Fa1034Ec9fdDB3B3` appears twice in `src/tokens/base.json` on the current `main`. Removing that single duplicate, the full list (including all 76 kStable entries) passes every assertion. Happy to split per-chain or adjust naming/logos if preferred.