### PR TITLE
docs: fix badge URL pointing to wrong repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # @uniswap/default-token-list
 
-[![Tests](https://github.com/Uniswap/token-lists/workflows/Tests/badge.svg)](https://github.com/Uniswap/default-token-list/actions?query=workflow%3ATests)
+[![Tests](https://github.com/Uniswap/default-token-list/actions/workflows/badge.svg)](https://github.com/Uniswap/default-token-list/actions?query=workflow%3ATests)
 [![npm](https://img.shields.io/npm/v/@uniswap/default-token-list)](https://unpkg.com/@uniswap/default-token-list@latest/)
 
 This NPM module and GitHub repo contains the default token list used in the Uniswap interface.


### PR DESCRIPTION
Minor documentation fix.