### PR TITLE
add: NATG, USDPT, GRVT (2026-07-16)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uniswap/default-token-list",
-  "version": "22.5.0",
+  "version": "22.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@uniswap/default-token-list",
-      "version": "22.5.0",
+      "version": "22.6.0",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "@ethersproject/address": "^5.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/default-token-list",
-  "version": "22.5.0",
+  "version": "22.6.0",
   "description": "The Uniswap default token list",
   "main": "build/uniswap-default.tokenlist.json",
   "scripts": {

--- a/src/tokens/mainnet.json
+++ b/src/tokens/mainnet.json
@@ -3260,7 +3260,7 @@
     "name": "NatGold",
     "symbol": "NATG",
     "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/102173495/standard/NATG-NatGold-Coin.png?1779808623"
+    "logoURI": "https://assets.coingecko.com/coins/images/102173495/large/NATG-NatGold-Coin.png?1779808623"
   },
   {
     "chainId": 1,
@@ -3268,6 +3268,6 @@
     "name": "Grvt",
     "symbol": "GRVT",
     "decimals": 18,
-    "logoURI": "https://assets.coingecko.com/coins/images/102172513/standard/grvt_400x400.jpg?1773653767"
+    "logoURI": "https://assets.coingecko.com/coins/images/102172513/large/grvt_400x400.jpg?1773653767"
   }
 ]

--- a/src/tokens/mainnet.json
+++ b/src/tokens/mainnet.json
@@ -3253,5 +3253,21 @@
     "symbol": "NES",
     "decimals": 18,
     "logoURI": "https://s2.coinmarketcap.com/static/img/coins/128x128/30140.png"
+  },
+  {
+    "chainId": 1,
+    "address": "0x59c323346F4f62aE18289F346501389392cf5939",
+    "name": "NatGold",
+    "symbol": "NATG",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/102173495/standard/NATG-NatGold-Coin.png?1779808623"
+  },
+  {
+    "chainId": 1,
+    "address": "0xAD29F2723fcdBcF665F210F25E06f97477e417cF",
+    "name": "Grvt",
+    "symbol": "GRVT",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/102172513/standard/grvt_400x400.jpg?1773653767"
   }
 ]

--- a/src/tokens/solana.json
+++ b/src/tokens/solana.json
@@ -1454,5 +1454,13 @@
     "symbol": "GEOD",
     "decimals": 9,
     "logoURI": "https://coin-images.coingecko.com/coins/images/31608/large/Circular_White.png?1696530424"
+  },
+  {
+    "chainId": 501000101,
+    "address": "HVWf8JmLoHs99Lw8Psf3fyqAtA4crWxCPkrmSdNjhNH3",
+    "name": "USDPT",
+    "symbol": "USDPT",
+    "decimals": 6,
+    "logoURI": "https://s2.coinmarketcap.com/static/img/coins/64x64/38850.png"
   }
 ]


### PR DESCRIPTION
## Summary
Add 3 token(s) to the default list.

| Symbol | Chain | Address | Decimals |
|--------|-------|---------|----------|
| NATG | Ethereum | `0x59c323346F4f62aE18289F346501389392cf5939` | 18 |
| USDPT | Solana | `HVWf8JmLoHs99Lw8Psf3fyqAtA4crWxCPkrmSdNjhNH3` | 6 |
| GRVT | Ethereum | `0xAD29F2723fcdBcF665F210F25E06f97477e417cF` | 18 |

## Verification
- [x] EIP-55 checksums verified
- [x] No duplicate entries
- [x] `yarn test` passes

## Linear tickets
- [CONS-2607](https://linear.app/uniswap/issue/CONS-2607/default-token-list-addition-natgold)
- [CONS-2606](https://linear.app/uniswap/issue/CONS-2606/default-token-list-addition-usdpt)
- [CONS-2605](https://linear.app/uniswap/issue/CONS-2605/default-token-list-addition-grvt)