### PR TITLE
add: STONKBROKER (2026-07-18)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/default-token-list",
-  "version": "22.6.0",
+  "version": "22.7.0",
   "description": "The Uniswap default token list",
   "main": "build/uniswap-default.tokenlist.json",
   "scripts": {

--- a/src/tokens/robinhood.json
+++ b/src/tokens/robinhood.json
@@ -698,5 +698,13 @@
     "name": "Nokia",
     "symbol": "NOK",
     "decimals": 18
+  },
+  {
+    "chainId": 4663,
+    "address": "0xe934e36A439C94017B64a3FecE66AF12099aBF50",
+    "name": "StonkBroker",
+    "symbol": "STONKBROKER",
+    "decimals": 18,
+    "logoURI": "https://www.stonkbrokers.cash/token-logo.png"
   }
 ]


### PR DESCRIPTION
## Summary
Add **STONKBROKER** (`$STONKBROKER`) to the Robinhood Chain default token list.

| Symbol | Chain | Address | Decimals |
|--------|-------|---------|----------|
| STONKBROKER | Robinhood (4663) | `0xe934e36A439C94017B64a3FecE66AF12099aBF50` | 18 |

### Project
- **Name:** StonkBroker / StonkBrokers
- **Website:** https://www.stonkbrokers.cash
- **Twitter:** https://x.com/ClutchMarkets
- **Explorer:** https://robinhoodchain.blockscout.com/token/0xe934e36a439c94017b64a3fece66af12099abf50
- **Logo:** https://www.stonkbrokers.cash/token-logo.png
- **Liquidity:** Uniswap V4 ETH/STONKBROKER on Robinhood (PoolManager `0x8366a39CC670B4001A1121B8F6A443A643e40951`, fee 1%, poolId `0xd33c8fd38b06e989cdbd4dffdefab71c4bdd415b24964c8d69e38ff35b068f92`)

StonkBrokers is a fixed 4,444 ERC-721 collection on Robinhood Chain with an Anvil NFTFi market (token↔NFT AMM + StockBooster dividend drops funded by trade fees). Created by Clutch Markets.

## Verification
- [x] EIP-55 checksum verified
- [x] No duplicate entries
- [x] ChainId 4663 (Robinhood) — `robinhood.json` already exists
- [ ] Linear ticket — please advise if a CX Token Request ticket is required for merge

## Notes
Happy to open a Linear CX Token Request if that is the preferred intake path for Robinhood listings.

Made with [Cursor](https://cursor.com)