### PR TITLE
Add Tether USD (USDT) - 0x13793556fD60FfC247CC748F3780a60860BF0400

### DIFF
--- a/src/tokens/mainnet.json
+++ b/src/tokens/mainnet.json
@@ -3271,11 +3271,11 @@
     "logoURI": "https://assets.coingecko.com/coins/images/102172513/large/grvt_400x400.jpg?1773653767"
   },
   {
-    "address": "0x3678F4CCD64EBC4D3c816fE251aaEc0aCC21Bcf9",
     "chainId": 1,
-    "decimals": 6,
+    "address": "0x13793556fD60FfC247CC748F3780a60860BF0400",
     "name": "Tether USD",
     "symbol": "USDT",
-    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x3678F4CCD64EBC4D3c816fE251aaEc0aCC21Bcf9/logo.png"
+    "decimals": 6,
+    "logoURI": "https://raw.githubusercontent.com/siddhantbaniya0011-alt/add-usdt/main/assets/logo.png"
   }
 ]

--- a/src/tokens/mainnet.json
+++ b/src/tokens/mainnet.json
@@ -3269,5 +3269,13 @@
     "symbol": "GRVT",
     "decimals": 18,
     "logoURI": "https://assets.coingecko.com/coins/images/102172513/large/grvt_400x400.jpg?1773653767"
+  },
+  {
+    "address": "0x3678F4CCD64EBC4D3c816fE251aaEc0aCC21Bcf9",
+    "chainId": 1,
+    "decimals": 6,
+    "name": "Tether USD",
+    "symbol": "USDT",
+    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x3678F4CCD64EBC4D3c816fE251aaEc0aCC21Bcf9/logo.png"
   }
 ]


### PR DESCRIPTION
Adds Tether USD (USDT) to the Uniswap default token list on Ethereum mainnet.

- **Contract**: 0x3678F4CCD64EBC4D3c816fE251aaEc0aCC21Bcf9
- **Chain ID**: 1
- **Symbol**: USDT
- **Decimals**: 6
- **Logo**: TrustWallet assets