### PR TITLE
add: U, cbHYPE, cbZEC, etc (2026-09-03)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uniswap/default-token-list",
-  "version": "22.14.0",
+  "version": "22.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@uniswap/default-token-list",
-      "version": "22.14.0",
+      "version": "22.15.0",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "@ethersproject/address": "^5.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/default-token-list",
-  "version": "22.14.0",
+  "version": "22.15.0",
   "description": "The Uniswap default token list",
   "main": "build/uniswap-default.tokenlist.json",
   "scripts": {

--- a/src/tokens/base.json
+++ b/src/tokens/base.json
@@ -746,5 +746,21 @@
     "symbol": "BASECAT",
     "decimals": 18,
     "logoURI": "https://coin-images.coingecko.com/coins/images/102175780/large/zi54rndmdx59nblfgry3d1pyckch.?1787558766"
+  },
+  {
+    "chainId": 8453,
+    "address": "0xB200000000000000000000451d033a5000cb479e",
+    "name": "Coinbase Wrapped Hyperliquid",
+    "symbol": "cbHYPE",
+    "decimals": 18,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/102176592/large/Coinbase_Wrapped_Staked_Hype_%28cbHYPE%29.png?1788278142"
+  },
+  {
+    "chainId": 8453,
+    "address": "0xB2000000000000000000008501b13360000cb2EC",
+    "name": "Coinbase Wrapped ZEC",
+    "symbol": "cbZEC",
+    "decimals": 8,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/102176591/large/Coinbase_Wrapped_ZEC_%28cbZEC%29.png?1788278133"
   }
 ]

--- a/src/tokens/bnb.json
+++ b/src/tokens/bnb.json
@@ -174,5 +174,21 @@
     "symbol": "DGAI",
     "decimals": 18,
     "logoURI": "https://coin-images.coingecko.com/coins/images/102175792/large/dgrid.png?1787573447"
+  },
+  {
+    "chainId": 56,
+    "address": "0xcE24439F2D9C6a2289F741120FE202248B666666",
+    "name": "United Stables",
+    "symbol": "U",
+    "decimals": 18,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/71157/large/united-stables-logo.jpg?1766061640"
+  },
+  {
+    "chainId": 56,
+    "address": "0x9BeEE89723cEeC27d7c2834bec6834208FFdc202",
+    "name": "Avalon",
+    "symbol": "AVL",
+    "decimals": 18,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/54119/large/AV.png?1738314011"
   }
 ]

--- a/src/tokens/mainnet.json
+++ b/src/tokens/mainnet.json
@@ -3317,5 +3317,21 @@
     "symbol": "FOLD",
     "decimals": 18,
     "logoURI": "https://coin-images.coingecko.com/coins/images/102174402/large/fold.jpg?1783586823"
+  },
+  {
+    "chainId": 1,
+    "address": "0xcE24439F2D9C6a2289F741120FE202248B666666",
+    "name": "United Stables",
+    "symbol": "U",
+    "decimals": 18,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/71157/large/united-stables-logo.jpg?1766061640"
+  },
+  {
+    "chainId": 1,
+    "address": "0x5c8D0C48810FD37A0A824D074ee290E64f7A8Fa2",
+    "name": "Avalon",
+    "symbol": "AVL",
+    "decimals": 18,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/54119/large/AV.png?1738314011"
   }
 ]

--- a/src/tokens/robinhood.json
+++ b/src/tokens/robinhood.json
@@ -1406,5 +1406,13 @@
     "symbol": "CASHCAT",
     "decimals": 18,
     "logoURI": "https://assets.coingecko.com/coins/images/102174280/standard/cashcat-logo.jpg?1782922765"
+  },
+  {
+    "chainId": 4663,
+    "address": "0xCEC185eB182c47d1bA1EFc84e6959e18cd620Be4",
+    "name": "Coinbase Wrapped BTC",
+    "symbol": "cbBTC",
+    "decimals": 8,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/40143/large/cbbtc.webp?1726136727"
   }
 ]


### PR DESCRIPTION
## Summary
Add 6 token entries (5 tokens) across 4 chains to the default list. Consolidates #2561, #2562, and #2563 into a single PR.

| Symbol | Chain | Address | Decimals |
|--------|-------|---------|----------|
| U | Ethereum | `0xcE24439F2D9C6a2289F741120FE202248B666666` | 18 |
| U | BNB Chain | `0xcE24439F2D9C6a2289F741120FE202248B666666` | 18 |
| AVL | Ethereum | `0x5c8D0C48810FD37A0A824D074ee290E64f7A8Fa2` | 18 |
| AVL | BNB Chain | `0x9BeEE89723cEeC27d7c2834bec6834208FFdc202` | 18 |
| cbHYPE | Base | `0xB200000000000000000000451d033a5000cb479e` | 18 |
| cbZEC | Base | `0xB2000000000000000000008501b13360000cb2EC` | 8 |
| cbBTC | Robinhood | `0xCEC185eB182c47d1bA1EFc84e6959e18cd620Be4` | 8 |

## Verification
- [x] EIP-55 checksums verified
- [x] No duplicate entries
- [x] JSON validity and required fields verified (`yarn test` requires live RPC locally; relying on CI)

## Linear tickets
- [CONS-3343](https://linear.app/uniswap/issue/CONS-3343/default-token-list-addition-united-stables)
- [CONS-3344](https://linear.app/uniswap/issue/CONS-3344/default-token-list-addition-coinbase-wrapped-hyperliquid)
- [CONS-3345](https://linear.app/uniswap/issue/CONS-3345/default-token-list-addition-coinbase-wrapped-zec)
- [CONS-3327](https://linear.app/uniswap/issue/CONS-3327/default-token-list-addition-avalon)
- [CONS-3302](https://linear.app/uniswap/issue/CONS-3302/default-token-list-addition-coinbase-wrapped-btc)

## Replaces
- #2563 (U, cbHYPE, cbZEC)
- #2562 (AVL)
- #2561 (cbBTC)