### PR TITLE
Add PENDLE to all other chains

### DIFF
--- a/src/tokens/arbitrum.json
+++ b/src/tokens/arbitrum.json
@@ -134,5 +134,13 @@
     "symbol": "DGAI",
     "decimals": 18,
     "logoURI": "https://coin-images.coingecko.com/coins/images/102175792/large/dgrid.png?1787573447"
+  },
+  {
+    "chainId": 42161,
+    "address": "0x0c880f6761F1af8d9Aa9C466984b80DAb9a8c9e8",
+    "name": "Pendle",
+    "symbol": "PENDLE",
+    "decimals": 18,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/15069/large/Pendle_Logo_Normal-03.png?1696514728"
   }
 ]

--- a/src/tokens/base.json
+++ b/src/tokens/base.json
@@ -762,5 +762,13 @@
     "symbol": "cbZEC",
     "decimals": 8,
     "logoURI": "https://coin-images.coingecko.com/coins/images/102176591/large/Coinbase_Wrapped_ZEC_%28cbZEC%29.png?1788278133"
+  },
+  {
+    "chainId": 8453,
+    "address": "0xA99F6e6785Da0F5d6fB42495Fe424BCE029Eeb3E",
+    "name": "Pendle",
+    "symbol": "PENDLE",
+    "decimals": 18,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/15069/large/Pendle_Logo_Normal-03.png?1696514728"
   }
 ]

--- a/src/tokens/bnb.json
+++ b/src/tokens/bnb.json
@@ -190,5 +190,13 @@
     "symbol": "AVL",
     "decimals": 18,
     "logoURI": "https://coin-images.coingecko.com/coins/images/54119/large/AV.png?1738314011"
+  },
+  {
+    "chainId": 56,
+    "address": "0xb3Ed0A426155B79B898849803E3B36552f7ED507",
+    "name": "Pendle",
+    "symbol": "PENDLE",
+    "decimals": 18,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/15069/large/Pendle_Logo_Normal-03.png?1696514728"
   }
 ]

--- a/src/tokens/monad.json
+++ b/src/tokens/monad.json
@@ -6,5 +6,13 @@
       "decimals": 6,
       "chainId": 143,
       "logoURI": "https://coin-images.coingecko.com/coins/images/66560/large/XAUt0_Token_Icon_Gold.png?1749747942"
+    },
+    {
+      "chainId": 143,
+      "address": "0x5E49E1f85813F2B65858860A3FA231b4186f2e0E",
+      "name": "Pendle",
+      "symbol": "PENDLE",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/15069/large/Pendle_Logo_Normal-03.png?1696514728"
     }
 ]

--- a/src/tokens/robinhood.json
+++ b/src/tokens/robinhood.json
@@ -1414,5 +1414,13 @@
     "symbol": "cbBTC",
     "decimals": 8,
     "logoURI": "https://coin-images.coingecko.com/coins/images/40143/large/cbbtc.webp?1726136727"
+  },
+  {
+    "chainId": 4663,
+    "address": "0x5E49E1f85813F2B65858860A3FA231b4186f2e0E",
+    "name": "Pendle",
+    "symbol": "PENDLE",
+    "decimals": 18,
+    "logoURI": "https://coin-images.coingecko.com/coins/images/15069/large/Pendle_Logo_Normal-03.png?1696514728"
   }
 ]

--- a/src/tokens/xlayer.json
+++ b/src/tokens/xlayer.json
@@ -14,6 +14,14 @@
       "symbol": "USDT0",
       "decimals": 6,
       "logoURI": "https://coin-images.coingecko.com/coins/images/53705/large/usdt0.jpg?1737086183"
+    },
+    {
+      "chainId": 196,
+      "address": "0x5E49E1f85813F2B65858860A3FA231b4186f2e0E",
+      "name": "Pendle",
+      "symbol": "PENDLE",
+      "decimals": 18,
+      "logoURI": "https://coin-images.coingecko.com/coins/images/15069/large/Pendle_Logo_Normal-03.png?1696514728"
     }
   ]
   


### PR DESCRIPTION
## Summary
Add 6 tokens to the default list.

| Symbol | Chain | Address | Decimals |
|--------|-------|---------|----------|
| PENDLE | Arbitrum | `0x0c880f6761F1af8d9Aa9C466984b80DAb9a8c9e8` | 18 |
| PENDLE | Base | `0xA99F6e6785Da0F5d6fB42495Fe424BCE029Eeb3E` | 18 |
| PENDLE | BNB | `0xb3Ed0A426155B79B898849803E3B36552f7ED507` | 18 |
| PENDLE | Monad | `0x5E49E1f85813F2B65858860A3FA231b4186f2e0E` | 18 |
| PENDLE | Robinhood | `0x5E49E1f85813F2B65858860A3FA231b4186f2e0E` | 18 |
| PENDLE | XLayer | `0x5E49E1f85813F2B65858860A3FA231b4186f2e0E` | 18 |

## Verification
- [x] EIP-55 checksums verified
- [x] No duplicate entries
- [x] `yarn test` passes