### PR TITLE
add: CAW (2026-09-10)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uniswap/default-token-list",
-  "version": "22.18.0",
+  "version": "22.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@uniswap/default-token-list",
-      "version": "22.18.0",
+      "version": "22.19.0",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "@ethersproject/address": "^5.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/default-token-list",
-  "version": "22.18.0",
+  "version": "22.19.0",
   "description": "The Uniswap default token list",
   "main": "build/uniswap-default.tokenlist.json",
   "scripts": {

--- a/src/tokens/arbitrum.json
+++ b/src/tokens/arbitrum.json
@@ -134,5 +134,13 @@
     "symbol": "DGAI",
     "decimals": 18,
     "logoURI": "https://coin-images.coingecko.com/coins/images/102175792/large/dgrid.png?1787573447"
+  },
+  {
+    "chainId": 42161,
+    "address": "0x16f1967565aaD72DD77588a332CE445e7cEF752b",
+    "name": "crow with knife",
+    "symbol": "CAW",
+    "decimals": 0,
+    "logoURI": "https://assets.coingecko.com/coins/images/36067/standard/200px.png?1710405601"
   }
 ]

--- a/src/tokens/base.json
+++ b/src/tokens/base.json
@@ -762,5 +762,13 @@
     "symbol": "cbZEC",
     "decimals": 8,
     "logoURI": "https://coin-images.coingecko.com/coins/images/102176591/large/Coinbase_Wrapped_ZEC_%28cbZEC%29.png?1788278133"
+  },
+  {
+    "chainId": 8453,
+    "address": "0xdfBEA88C4842d30c26669602888d746D30F9D60d",
+    "name": "crow with knife",
+    "symbol": "CAW",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/36067/standard/200px.png?1710405601"
   }
 ]

--- a/src/tokens/bnb.json
+++ b/src/tokens/bnb.json
@@ -198,5 +198,13 @@
     "symbol": "ONE",
     "decimals": 18,
     "logoURI": "https://coin-images.coingecko.com/coins/images/67058/large/ONE_logo_200x200.png?1787648216"
+  },
+  {
+    "chainId": 56,
+    "address": "0xdfBEA88C4842d30c26669602888d746D30F9D60d",
+    "name": "crow with knife",
+    "symbol": "CAW",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/36067/standard/200px.png?1710405601"
   }
 ]

--- a/src/tokens/polygon.json
+++ b/src/tokens/polygon.json
@@ -350,5 +350,13 @@
     "symbol": "KII",
     "decimals": 18,
     "logoURI": "https://www.geckoterminal.com/_next/image?url=https%3A%2F%2Fassets.geckoterminal.com%2Fvz4uzyti7ibz7t9c23rb6jp6lbep&w=128&q=75"
+  },
+  {
+    "chainId": 137,
+    "address": "0xbbBBbBbBB7949dcC7d1539c91b81A5BF09E37bDB",
+    "name": "crow with knife",
+    "symbol": "CAW",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/36067/standard/200px.png?1710405601"
   }
 ]

--- a/src/tokens/robinhood.json
+++ b/src/tokens/robinhood.json
@@ -1414,5 +1414,13 @@
     "symbol": "cbBTC",
     "decimals": 8,
     "logoURI": "https://coin-images.coingecko.com/coins/images/40143/large/cbbtc.webp?1726136727"
+  },
+  {
+    "chainId": 4663,
+    "address": "0x777777783478dAdf54678d1D92DaD3fB5Bd42Eb2",
+    "name": "crow with knife",
+    "symbol": "CAW",
+    "decimals": 18,
+    "logoURI": "https://assets.coingecko.com/coins/images/36067/standard/200px.png?1710405601"
   }
 ]

--- a/src/tokens/solana.json
+++ b/src/tokens/solana.json
@@ -1478,5 +1478,13 @@
     "symbol": "SOFID",
     "decimals": 6,
     "logoURI": "https://assets.coingecko.com/coins/images/71688/standard/CRY25-3266080_StableCoinLogo.png?1768922282"
+  },
+  {
+    "chainId": 501000101,
+    "address": "CAW777xcHVTQZ4CRwVQGB8CV1BVKPm5bNVxFJHWFKiH8",
+    "name": "crow with knife",
+    "symbol": "CAW",
+    "decimals": 2,
+    "logoURI": "https://assets.coingecko.com/coins/images/36067/standard/200px.png?1710405601"
   }
 ]


### PR DESCRIPTION
## Summary

Add crow with knife (CAW) to 6 chains. 48 insertions across 6 token files, plus a separate commit bumping the minor version to 22.18.0. No existing entries modified.

| Chain | chainId | Address | Decimals |
|---|---|---|---|
| Robinhood | 4663 | 0x777777783478dAdf54678d1D92DaD3fB5Bd42Eb2 | 18 |
| Base | 8453 | 0xdfBEA88C4842d30c26669602888d746D30F9D60d | 18 |
| BNB | 56 | 0xdfBEA88C4842d30c26669602888d746D30F9D60d | 18 |
| Polygon | 137 | 0xbbBBbBbBB7949dcC7d1539c91b81A5BF09E37bDB | 18 |
| Arbitrum | 42161 | 0x16f1967565aaD72DD77588a332CE445e7cEF752b | 0 |
| Solana | 501000101 | CAW777xcHVTQZ4CRwVQGB8CV1BVKPm5bNVxFJHWFKiH8 | 2 |

All six are registered contract addresses on
https://www.coingecko.com/en/coins/crow-with-knife

## Liquidity

- Robinhood v3 CAW/WETH 0.3% `0xF1DEA610BCd74419924f511F0aB324E5C591074D` — 3.01 WETH + 1.06T CAW
- Base v2 CAW/WETH `0x110751cbf035862f59a10528dd54b9ac2b048906` — 2.375T CAW + 6.57 WETH

**Arbitrum's 0 decimals and Solana's 2 decimals are correct, not typos** — both are contract-verified and CoinGecko records the same values.

## Verification

- [x] Metadata verified by direct `name()` / `symbol()` / `decimals()` RPC calls per chain
- [x] EIP-55 checksums verified
- [x] No duplicate addresses, symbols, or names
- [x] `yarn test` passes
- [x] Rebased on current `main`; no merge commits