### PR TITLE
add: SPRL (2026-09-11)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uniswap/default-token-list",
-  "version": "22.19.0",
+  "version": "22.20.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@uniswap/default-token-list",
-      "version": "22.19.0",
+      "version": "22.20.0",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "@ethersproject/address": "^5.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/default-token-list",
-  "version": "22.19.0",
+  "version": "22.20.0",
   "description": "The Uniswap default token list",
   "main": "build/uniswap-default.tokenlist.json",
   "scripts": {

--- a/src/tokens/robinhood.json
+++ b/src/tokens/robinhood.json
@@ -1414,5 +1414,13 @@
     "symbol": "cbBTC",
     "decimals": 8,
     "logoURI": "https://coin-images.coingecko.com/coins/images/40143/large/cbbtc.webp?1726136727"
+  },
+  {
+    "chainId": 4663,
+    "address": "0xb22A893a4afDCE12871e61229130490F9422B5B6",
+    "name": "Spiral Stake",
+    "symbol": "SPRL",
+    "decimals": 18,
+    "logoURI": "https://spiralstake.xyz/tokens/sprl.jpg"
   }
 ]


### PR DESCRIPTION
## Summary
Add 1 token to the default list.

| Symbol | Chain | Address | Decimals |
|--------|-------|---------|----------|
| SPRL | Robinhood Chain (4663) | `0xb22A893a4afDCE12871e61229130490F9422B5B6` | 18 |

Spiral Stake ($SPRL) is the protocol token of [Spiral Stake](https://spiralstake.xyz), launched 2026-09-08 on Robinhood Chain via Pons v2 and trading in Uniswap v4 pool `0xadbe28c40e4548059348e58c470022d0b81caad920b18b258d864dcfcdfd5418` (ETH/SPRL).

- CoinGecko (same network + address): https://www.coingecko.com/en/coins/spiral-stake
- Token page publishing the address: https://spiralstake.xyz/token
- Explorer: https://robinhoodchain.blockscout.com/token/0xb22A893a4afDCE12871e61229130490F9422B5B6

## Verification
- [x] EIP-55 checksum verified (`node scripts/checksum.js` → `OK`)
- [x] `name()`, `symbol()`, `decimals()` read from the contract on Robinhood Chain match the entry
- [x] No duplicate entries — address, symbol and name absent from `src/tokens/robinhood.json`
- [x] Robinhood Chain is the only deployment
- [x] Entry appended at the end of `src/tokens/robinhood.json`, existing key order, 2-space indent
- [x] `yarn test` passes (6 passing)
- [x] `npm version minor` → 22.20.0

Closes #2574
