### PR TITLE
update: UNI Base bridgeInfo (2026-09-11)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uniswap/default-token-list",
-  "version": "22.19.0",
+  "version": "23.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@uniswap/default-token-list",
-      "version": "22.19.0",
+      "version": "23.0.0",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "@ethersproject/address": "^5.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/default-token-list",
-  "version": "22.19.0",
+  "version": "23.0.0",
   "description": "The Uniswap default token list",
   "main": "build/uniswap-default.tokenlist.json",
   "scripts": {

--- a/src/tokens/base.json
+++ b/src/tokens/base.json
@@ -389,7 +389,14 @@
     "name": "Uniswap",
     "symbol": "UNI",
     "decimals": 18,
-    "logoURI": "https://ethereum-optimism.github.io/data/UNI/logo.png"
+    "logoURI": "https://ethereum-optimism.github.io/data/UNI/logo.png",
+    "extensions": {
+      "bridgeInfo": {
+        "1": {
+          "tokenAddress": "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984"
+        }
+      }
+    }
   },
   {
     "chainId": 8453,

--- a/src/tokens/mainnet.json
+++ b/src/tokens/mainnet.json
@@ -53,7 +53,14 @@
     "symbol": "UNI",
     "decimals": 18,
     "chainId": 1,
-    "logoURI": "ipfs://QmXttGpZrECX5qCyXbBQiqgQNytVGeZW5Anewvh2jc4psg"
+    "logoURI": "ipfs://QmXttGpZrECX5qCyXbBQiqgQNytVGeZW5Anewvh2jc4psg",
+    "extensions": {
+      "bridgeInfo": {
+        "8453": {
+          "tokenAddress": "0xc3De830EA07524a0761646a6a4e4be0e114a3C83"
+        }
+      }
+    }
   },
   {
     "name": "Tether USD",


### PR DESCRIPTION
## Summary
Add explicit `extensions.bridgeInfo` linking UNI on Ethereum and UNI on Base, so multichain grouping downstream treats the Base deployment as part of the Uniswap token instead of a standalone token.

| Chain | Address | bridgeInfo added |
|-------|---------|------------------|
| Ethereum (1) | `0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984` | `8453 → 0xc3De830EA07524a0761646a6a4e4be0e114a3C83` |
| Base (8453) | `0xc3De830EA07524a0761646a6a4e4be0e114a3C83` | `1 → 0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984` |

## Why
Found in the Tokens Search V2 bug bash: searching "UNI" returns the 9-chain Uniswap row plus a second, detached "Uniswap / UNI" row that is Base only. data-ingestion groups tokens from token-list `bridgeInfo` first and CoinGecko platforms second. Base UNI has neither signal:

- The published list's mainnet UNI `bridgeInfo` covers 10, 56, 130, 42161 and 43114 (all generated at build time by `@uniswap/token-list-bridge-utils`), and the Base entry has none. The bridge utils do not derive a Base mapping for UNI even though the Superchain token list carries `0xc3De…` on chainId 8453.
- CoinGecko's `uniswap` coin lists no `base` platform, and `/coins/base/contract/0xc3de…` returns "coin not found".

Explicit `bridgeInfo` in the source files is the same pattern USDT already uses for Celo (`42220`), and the build merges it with the generated mappings.

## Verification
- [x] EIP-55 checksums verified with `node scripts/checksum.js`
- [x] Both files still parse; the diff touches only the two UNI entries
- [x] Base address matches the Superchain token list (`static.optimism.io`) entry for chainId 8453
- [ ] `yarn test` / `yarn build` could not run on my machine: the bridge utils' mainnet RPC (`ethereum-rpc.publicnode.com`) is unreachable here and a clean checkout of `main` fails identically, so CI is the gate for this PR

Version bumped with `npm version major` per this repo's convention for updates to existing entries.

## Linear tickets
- [CONS-3428](https://linear.app/uniswap/issue/CONS-3428/uni-on-base-shows-as-detached-rows-in-v2-grouped-with-flag-off)
